### PR TITLE
Upgrade Babylon to v8.2.1

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,14 @@
+node_modules/*
+coverage/
+
+# typescript files
+src/*
+
+# config files
+.eslintrc.json
+tsconfig.json
+tsconfig.build.json
+.github/
+babel.config.js
+.prettierrc
+jest.config.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "babylon-testing-library",
-    "version": "1.0.0-alpha",
+    "version": "1.0.0-alpha.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "babylon-testing-library",
-            "version": "1.0.0-alpha",
+            "version": "1.0.0-alpha.1",
             "license": "MIT",
             "dependencies": {
-                "@babylonjs/core": "^7.5.0",
-                "@babylonjs/gui": "^7.5.0",
+                "@babylonjs/core": "^8.2.2",
+                "@babylonjs/gui": "^8.2.2",
                 "@testing-library/dom": "^10.1.0"
             },
             "devDependencies": {
@@ -32,6 +32,9 @@
                 "tslib": "^2.6.2",
                 "typescript": "^5.4.5",
                 "typescript-eslint": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babylonjs/core": "^8.2.2"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -1858,16 +1861,18 @@
             }
         },
         "node_modules/@babylonjs/core": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-7.5.0.tgz",
-            "integrity": "sha512-iP/z+j1eRrpv5g/JyqxMAuT7UVdfBWPHZ0Bl/89onq9hZmeyckHM+gXNpepo4sFrxoDefdAblh5eyVbN6iiXDg=="
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-8.2.2.tgz",
+            "integrity": "sha512-gUPpZ5cnLwrDbUX+LwyoC6rjYqkoNc+JIlPATRRO03I9cY/c4bGW0sZvGPWbhM5YxgJogWO34zjInCzUGpqOmA==",
+            "license": "Apache-2.0"
         },
         "node_modules/@babylonjs/gui": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/@babylonjs/gui/-/gui-7.5.0.tgz",
-            "integrity": "sha512-kqS9HtveyG7W918u+h01JZBv9cDoPda3/o/vjbiZOUHem71Lj5MR7WeVr8bSRPbVRyj3mUdL2o1w2tYRPiDC/w==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/@babylonjs/gui/-/gui-8.2.2.tgz",
+            "integrity": "sha512-LZEvdWTN7Qby44m7sYMxIsGgY/yQYw5ippCQd6rbARApz0Vp0kFmCfI5EX56tAPEE/yevBcur5jhQbr+HVwYOQ==",
+            "license": "Apache-2.0",
             "peerDependencies": {
-                "@babylonjs/core": "^7.0.0"
+                "@babylonjs/core": "^8.0.0"
             }
         },
         "node_modules/@bcoe/v8-coverage": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "babylon-testing-library",
-    "version": "1.0.0-alpha",
+    "version": "1.0.0-alpha.1",
     "description": "Simple utilities that encourage good testing practices for Babylon.js",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "babylon-testing-library",
-    "version": "1.0.0-alpha.1",
+    "version": "2.0.0",
     "description": "Simple utilities that encourage good testing practices for Babylon.js",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
@@ -47,8 +47,11 @@
         "typescript-eslint": "^7.8.0"
     },
     "dependencies": {
-        "@babylonjs/core": "^7.5.0",
-        "@babylonjs/gui": "^7.5.0",
+        "@babylonjs/core": "^8.2.2",
+        "@babylonjs/gui": "^8.2.2",
         "@testing-library/dom": "^10.1.0"
+    },
+    "peerDependencies": {
+        "@babylonjs/core": "^8.2.2"
     }
 }


### PR DESCRIPTION
Upgrades babylon-testing-library to the latest version of Babylon. 

This also pins Babylon ^8.2.1 as a peer dependency, since we rely on `instanceof` to correctly traverse the UI container passed into `getByText`, etc.