### PR TITLE
Do not include Babylon as a direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
             "version": "2.0.1",
             "license": "MIT",
             "dependencies": {
-                "@babylonjs/core": "^8.2.2",
-                "@babylonjs/gui": "^8.2.2",
                 "@testing-library/dom": "^10.1.0"
             },
             "devDependencies": {
                 "@babel/core": "^7.24.5",
                 "@babel/preset-env": "^7.24.5",
                 "@babel/preset-typescript": "^7.24.1",
+                "@babylonjs/core": "^8.2.2",
+                "@babylonjs/gui": "^8.2.2",
                 "@jest/globals": "^29.7.0",
                 "@swc/cli": "^0.3.12",
                 "@swc/core": "^1.5.3",
@@ -34,7 +34,8 @@
                 "typescript-eslint": "^7.8.0"
             },
             "peerDependencies": {
-                "@babylonjs/core": "^8.2.2"
+                "@babylonjs/core": "^8.2.2",
+                "@babylonjs/gui": "^8.2.2"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -1864,12 +1865,14 @@
             "version": "8.2.2",
             "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-8.2.2.tgz",
             "integrity": "sha512-gUPpZ5cnLwrDbUX+LwyoC6rjYqkoNc+JIlPATRRO03I9cY/c4bGW0sZvGPWbhM5YxgJogWO34zjInCzUGpqOmA==",
+            "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/@babylonjs/gui": {
             "version": "8.2.2",
             "resolved": "https://registry.npmjs.org/@babylonjs/gui/-/gui-8.2.2.tgz",
             "integrity": "sha512-LZEvdWTN7Qby44m7sYMxIsGgY/yQYw5ippCQd6rbARApz0Vp0kFmCfI5EX56tAPEE/yevBcur5jhQbr+HVwYOQ==",
+            "dev": true,
             "license": "Apache-2.0",
             "peerDependencies": {
                 "@babylonjs/core": "^8.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "babylon-testing-library",
-    "version": "2.0.1",
+    "version": "3.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "babylon-testing-library",
-            "version": "2.0.1",
+            "version": "3.0.0",
             "license": "MIT",
             "dependencies": {
                 "@testing-library/dom": "^10.1.0"
@@ -34,8 +34,8 @@
                 "typescript-eslint": "^7.8.0"
             },
             "peerDependencies": {
-                "@babylonjs/core": "^8.2.2",
-                "@babylonjs/gui": "^8.2.2"
+                "@babylonjs/core": "^7.0.0 || ^8.0.0",
+                "@babylonjs/gui": "^7.0.0 || ^8.0.0"
             }
         },
         "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "babylon-testing-library",
-    "version": "2.0.1",
+    "version": "3.0.0",
     "description": "Simple utilities that encourage good testing practices for Babylon.js",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
@@ -30,6 +30,8 @@
         "@babel/core": "^7.24.5",
         "@babel/preset-env": "^7.24.5",
         "@babel/preset-typescript": "^7.24.1",
+        "@babylonjs/core": "^8.2.2",
+        "@babylonjs/gui": "^8.2.2",
         "@jest/globals": "^29.7.0",
         "@swc/cli": "^0.3.12",
         "@swc/core": "^1.5.3",
@@ -47,11 +49,10 @@
         "typescript-eslint": "^7.8.0"
     },
     "dependencies": {
-        "@babylonjs/core": "^8.2.2",
-        "@babylonjs/gui": "^8.2.2",
         "@testing-library/dom": "^10.1.0"
     },
     "peerDependencies": {
-        "@babylonjs/core": "^8.2.2"
+        "@babylonjs/core": "^8.2.2",
+        "@babylonjs/gui": "^8.2.2"
     }
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "@testing-library/dom": "^10.1.0"
     },
     "peerDependencies": {
-        "@babylonjs/core": "^8.2.2",
-        "@babylonjs/gui": "^8.2.2"
+        "@babylonjs/core": "^7.0.0 || ^8.0.0",
+        "@babylonjs/gui": "^7.0.0 || ^8.0.0"
     }
 }


### PR DESCRIPTION
- Specifies Babylon 8.2.2 as the devDependency
- Specifies Babylon 7 and 8 as peer dependencies. We should be able to specify 7, since we do not rely on any 8-specific APIs.