### PR TITLE
Switch npm publish to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,10 +14,12 @@ jobs:
             # Setup .npmrc file to publish to npm
             - uses: actions/setup-node@v4
               with:
-                  node-version: '20.x'
+                  node-version: '24.x'
                   registry-url: 'https://registry.npmjs.org'
+            # npm trusted publishing (OIDC) requires npm >= 11.5.1; no
+            # NPM_TOKEN secret is used — auth comes from the id-token
+            # permission plus the trusted-publisher config on npmjs.com.
+            - run: npm install -g npm@latest
             - run: npm ci
             - run: npm run build
             - run: npm publish --provenance --access public
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The 3.1.0 release workflow failed at `npm publish` with a 404 on PUT (run 27390247874) — npm's auth-masking response for a dead token. The `NPM_TOKEN` secret dates to the 3.0.0 publish (Sept 2025); npm revoked classic automation tokens in late 2025, so token-based publishes from this workflow will keep failing until the secret is replaced.

This PR switches the workflow to [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) (OIDC) — no long-lived secret at all, which is where npm is pushing everyone (and what @testing-library/react switched to in 16.3.1). The workflow already had `id-token: write` for provenance; the changes are Node 24 + `npm install -g npm@latest` (trusted publishing needs npm ≥ 11.5.1) and no `NODE_AUTH_TOKEN`.

**One-time setup required before this works** (needs the npm package owner — currently `henry_rbckr`): on npmjs.com → `babylon-testing-library` → Settings → Trusted Publisher → GitHub Actions, with org `rebeckerspecialties`, repo `babylon-testing-library`, workflow `release.yaml` (no environment).

**Alternative if trusted publishing is unwanted:** generate a new granular automation token (publish scope for this package, 2FA-bypass), update the `NPM_TOKEN` repo secret, and close this PR — the old workflow then works as-is.

**Release runbook once auth works** (everything is consolidated into a single 3.1.0 — the original 3.1.0 tag/release was deleted before ever reaching npm): merge #35, then create a GitHub release tagged `3.1.0`; the workflow publishes one release containing the wait helpers, queries, mesh pointer simulation, WebXR mocks, poke stack, and matchers.