### PR TITLE
v3.1.0: real-time waits follow-ups — name/mesh queries, mesh pointer simulation, WebXR mocks, poke stack, matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,28 @@ expect(onClick).toHaveBeenCalledTimes(1);
 
 Disabled hitboxes are skipped (`isEnabled()` folds in every ancestor — palm-up gates and face toggles gate pokes the same way they gate rendering), so a test poking a gated-off menu fails the way the device does.
 
+#### A complete hand-menu example
+
+[`src/examples/handMenu.spec.ts`](./src/examples/handMenu.spec.ts) is a runnable, headless WebXR hand menu composed entirely from this library's public API: a menu node with two poke buttons (invisible thin hitbox + visible face that raises on hover, skips its press squeeze for `xr-near` pokes, clicks on release), a mock tracked hand whose `index-finger-tip` joint mesh is moved frame by frame, and the per-frame wiring an app uses with a real `WebXRHand`:
+
+```js
+const hand = createMockXrHand({ 'index-finger-tip': fingerTipMesh });
+const mem = createPokeMemory();
+
+scene.onBeforeRenderObservable.add(() => {
+    const tip = hand.getJointMesh('index-finger-tip');
+    if (tip) {
+        pokeFrame(scene, tip.absolutePosition, hitboxes, mem, now);
+    } else {
+        pokeRelease(scene, mem, now); // tracking loss
+    }
+});
+```
+
+It covers the full interaction surface: click choreography (and that only the poked button clicks), hover raise/lower, the skipped squeeze for fingertip pokes, palm-down gating via `setEnabled` on the menu root, double-tap debounce, and tracking loss mid-press without stale re-fires.
+
+Two things differ on a real device and are intentionally out of headless scope: the menu node carries Babylon's `HandConstraintBehavior` for palm-up summoning — configure it with `HandConstraintVisibility.PALM_UP` explicitly if pokes drive your menu, because the default `PALM_AND_GAZE` disables the node the moment the user looks away from the hand they are poking by feel — and real hand-tracking input arrives through `WebXRHandTracking` rather than a test-driven joint mesh. In headless tests, palm gating reduces to `setEnabled`, which the poke pipeline honors identically.
+
 ### Babylon-aware matchers
 
 ```js

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install --save-dev babylon-testing-library
 
 ## API
 
-Babylon Testing Library implements a partial and modified API of the [DOM Testing Library](https://testing-library.com/docs/queries/about). In the alpha release, Babylon only includes utilities for interacting with the Babylon GUI. Utilities for interacting with 3D meshes will be included for the first release.
+Babylon Testing Library implements a partial and modified API of the [DOM Testing Library](https://testing-library.com/docs/queries/about). Queries cover Babylon GUI controls and 3D meshes; events cover GUI control observables (`fireEvent`) and scene-level pointer picks on meshes (`clickMesh` and friends). WebXR mocks and Babylon-aware matchers round out headless testing of hand- and controller-driven UI.
 
 ### Queries
 
@@ -49,6 +49,64 @@ Query the current text value of an InputText control.
 const firstNameText = getByDisplayValue(scene, 'First Name');
 expect(firstNameText.text).toEqual('First Name');
 ```
+
+#### ByName
+
+Query a GUI control by its Babylon `name` — the engine-native equivalent of a test id. Prefer the user-facing queries above where possible; reach for ByName for icon buttons and other controls with no queryable text.
+
+```js
+const button = getByName(scene, 'searchButton');
+const late = await findByName(scene, 'lateButton'); // waits in real elapsed time
+```
+
+#### ByMeshName
+
+Query 3D meshes in a scene by name. The `findBy*` variants wait in real elapsed time, which suits meshes that appear via genuinely asynchronous asset loads.
+
+```js
+const hitBox = getByMeshName(scene, 'hitBox');
+const loaded = await findByMeshName(scene, 'avatar', { timeout: 20000 });
+```
+
+### Mesh pointer simulation
+
+Mesh interactions don't flow through GUI control observables — Babylon delivers them through `scene.onPointerObservable` with a `PickingInfo` from a ray pick. These helpers perform a real pick against the mesh and notify the scene observable exactly as Babylon's input layer would:
+
+```js
+await clickMesh(scene, hitBox); // ray pick → pointer down + pointer up
+await hoverMesh(scene, hitBox); // pointer move
+await fireMeshPointer(scene, hitBox, PointerEventTypes.POINTERUP, {
+    pointerType: 'xr-near', // tag near-interaction pokes
+});
+```
+
+Picks render the scene and recompute the target inside every retry (a stale pick target is a classic source of CI flakes), honor `isPickable`/`isEnabled`/`isVisible` by default — a disabled button is not clickable in tests, just like on device — and enforce their timeout in real elapsed time under fake timers. The ray origin defaults to the active camera's position; pass `origin` explicitly for camera-less scenes. `pickThinInstance(scene, mesh, index)` ray-picks a specific thin instance.
+
+### WebXR mocks
+
+Headless mocks for the WebXR surface that hand- and controller-menu code touches — no device, no session, no controller GLBs. All observables are real Babylon `Observable`s; tests drive them with `notifyObservers`.
+
+```js
+const hand = createMockXrHand({ 'index-finger-tip': tipMesh });
+const experience = createMockXrExperience({
+    handTrackingEnabled: true,
+    getHandByHandedness: () => hand,
+});
+```
+
+Also available: `createMockXrController` (shared button/axis observables), `createMockXrControllerWithBindings` (distinct observables per component), `createMockXrInputSource`, `createMockXRSession` (listener registry you can fire), and `buildMockControllersFromProfile`, which fabricates the min/max/value transform nodes from a motion-controller profile so button/thumbstick animation code runs without loading assets.
+
+### Babylon-aware matchers
+
+```js
+import { setupBabylonExpect } from 'babylon-testing-library';
+setupBabylonExpect(); // e.g. in a jest setup file
+
+expect(node.position).toEqualVector3(new Vector3(0, 0.02, 0));
+expect(mesh.rotationQuaternion).toEqualQuaternion(Quaternion.Identity(), 1e-6);
+```
+
+`toEqualVector3`, `toEqualQuaternion`, `toEqualMatrix`, `toEqualColor3`, and `toEqualColor4` compare via Babylon's own `equals`, with an optional epsilon argument mapping to `equalsWithEpsilon`. The raw matcher map is exported as `babylonMatchers` for direct `expect.extend` use in other runners.
 
 ### Events
 
@@ -131,7 +189,7 @@ await waitForRealTime(callback, { wrapper: act });
 
 A small set of queries is implemented for the alpha release. We plan to implement the remaining queries exported from DOM testing library, but it's not clear what the corresponding implementation will be for queries like `getByLabelText`, `getByAltText`, and `getByTitle`. Babylon is not as complete in its accessibility standards as the DOM, so we may need to lean on user accessibility tagging to implement these queries.
 
-We will also want to extend the DOM testing API to allow us to query 3D meshes. It's not clear precisely how the existing queries map to a 3D sphere, for example. We want to be careful about maintaining high rigor around accessibility while implementing queries that map to how users parse a 3D scene. These will likely be queries around mesh transformation (scale, position, rotation), color, and role (selectable, clickable, collidable, etc.).
+Meshes can now be queried by name (`*ByMeshName`) and interacted with via real ray picks (`clickMesh`), but richer 3D queries remain open. It's not clear precisely how the existing queries map to a 3D sphere, for example. We want to be careful about maintaining high rigor around accessibility while implementing queries that map to how users parse a 3D scene. These will likely be queries around mesh transformation (scale, position, rotation), color, and role (selectable, clickable, collidable, etc.).
 
 ### Events
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,26 @@ const experience = createMockXrExperience({
 
 Also available: `createMockXrController` (shared button/axis observables), `createMockXrControllerWithBindings` (distinct observables per component), `createMockXrInputSource`, `createMockXRSession` (listener registry you can fire), and `buildMockControllersFromProfile`, which fabricates the min/max/value transform nodes from a motion-controller profile so button/thumbstick animation code runs without loading assets.
 
+### Finger-poke simulation (near interaction)
+
+A complete, allocation-free "poke a 3D button with a fingertip" stack — drive hand-tracked menu interactions headlessly from nothing but fingertip world positions, tuned on real hardware:
+
+- `probePoke(fingerTipWorld, hitboxWorldMatrix, lateralMargin)` — projects a fingertip into a hitbox's oriented frame; the thinnest axis is the press axis.
+- `stepPoke(mem, candidate, nowMs, thresholds)` — single-finger state machine emitting `move`/`down`/`up` with press/release hysteresis and a per-press debounce (`DEFAULT_POKE_THRESHOLDS`: hover 20mm, press 1mm, release 4mm, 250ms).
+- `pokeFrame(scene, fingerTipWorld, hitboxes, mem, nowMs, thresholds?)` — probes the enabled hitboxes, advances the machine, and injects synthetic `PointerInfo`s (tagged `pointerType: 'xr-near'`, see `POKE_POINTER_TYPE`) into `scene.onPointerObservable`, so mesh-button pipelines react exactly as they would to a controller pointer. `pokeRelease(scene, mem, nowMs, thresholds?)` ends an in-progress poke on tracking loss without leaving stuck hover/press state.
+
+```js
+const mem = createPokeMemory();
+
+pokeFrame(scene, new Vector3(0, 0.01, 0), [hitBox], mem, 0); // hover
+pokeFrame(scene, new Vector3(0, 0, 0), [hitBox], mem, 16); // press
+pokeFrame(scene, new Vector3(0, 0.01, 0), [hitBox], mem, 32); // withdraw → click
+
+expect(onClick).toHaveBeenCalledTimes(1);
+```
+
+Disabled hitboxes are skipped (`isEnabled()` folds in every ancestor — palm-up gates and face toggles gate pokes the same way they gate rendering), so a test poking a gated-off menu fails the way the device does.
+
 ### Babylon-aware matchers
 
 ```js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "babylon-testing-library",
-    "version": "3.2.0",
+    "version": "3.1.0",
     "description": "Simple utilities that encourage good testing practices for Babylon.js",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "babylon-testing-library",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "description": "Simple utilities that encourage good testing practices for Babylon.js",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/event.spec.ts
+++ b/src/event.spec.ts
@@ -80,6 +80,18 @@ describe('event', () => {
         }
     );
 
+    it('fires pointerMove on onPointerMoveObservable (regression: was wired to pointer up)', () => {
+        const moveSpy = jest.fn();
+        const upSpy = jest.fn();
+        expectedControl.onPointerMoveObservable.add(moveSpy as null);
+        expectedControl.onPointerUpObservable.add(upSpy as null);
+
+        fireEvent.pointerMove(expectedControl);
+
+        expect(moveSpy).toHaveBeenCalledTimes(1);
+        expect(upSpy).not.toHaveBeenCalled();
+    });
+
     it('should throw when fireEvent is called with a bad observable name', () => {
         expect(() => {
             fireEvent(expectedControl, {

--- a/src/eventMap.ts
+++ b/src/eventMap.ts
@@ -3,8 +3,8 @@ import { Vector2WithInfo } from '@babylonjs/gui';
 
 export type EventMap = {
     pointerMove: {
-        observableName: 'onPointerUpObservable';
-        defaultInit: Vector2WithInfo;
+        observableName: 'onPointerMoveObservable';
+        defaultInit: Vector2;
     };
     pointerEnter: {
         observableName: 'onPointerEnterObservable';
@@ -35,9 +35,11 @@ export type EventMap = {
 const DEFAULT_VECTOR2_WITH_INFO = new Vector2WithInfo(Vector2.Zero());
 
 export const eventMap: EventMap = {
+    // onPointerMoveObservable carries plain Vector2 coordinates, unlike the
+    // other pointer observables' Vector2WithInfo.
     pointerMove: {
-        observableName: 'onPointerUpObservable',
-        defaultInit: DEFAULT_VECTOR2_WITH_INFO,
+        observableName: 'onPointerMoveObservable',
+        defaultInit: Vector2.Zero(),
     },
     pointerEnter: {
         observableName: 'onPointerEnterObservable',

--- a/src/examples/handMenu.spec.ts
+++ b/src/examples/handMenu.spec.ts
@@ -1,0 +1,311 @@
+/**
+ * A complete, headless WebXR hand-menu example — the capstone for the
+ * library's XR testing pieces, composed entirely from public API:
+ *
+ *   - a menu node carrying two poke buttons (in a real session this node
+ *     would also carry Babylon's HandConstraintBehavior — see the README
+ *     walkthrough for the on-device configuration notes);
+ *   - an OrnamentButton-style mesh button: invisible thin hitbox over a
+ *     visible face that raises on hover, skips its press-squeeze for
+ *     fingertip pokes, and fires onClick on release;
+ *   - a mock hand (createMockXrHand) whose index-finger-tip joint mesh is
+ *     moved frame by frame, with a scene.onBeforeRenderObservable observer
+ *     feeding the fingertip position to pokeFrame — the same wiring an app
+ *     uses with a real WebXRHand;
+ *   - pokeRelease on tracking loss.
+ *
+ * Everything runs on NullEngine: no device, no session, no assets.
+ */
+import {
+    AbstractMesh,
+    Engine,
+    FreeCamera,
+    Mesh,
+    MeshBuilder,
+    NullEngine,
+    PointerEventTypes,
+    PointerInfo,
+    Quaternion,
+    Scene,
+    TransformNode,
+    Vector3,
+    WebXRHand,
+} from '@babylonjs/core';
+import {
+    createMockXrHand,
+    createPokeMemory,
+    DEFAULT_POKE_THRESHOLDS,
+    getByMeshName,
+    POKE_POINTER_TYPE,
+    pokeFrame,
+    pokeRelease,
+    PokeMemory,
+    setupBabylonExpect,
+} from '../index';
+
+setupBabylonExpect();
+
+const FRAME_MS = 16;
+const HOVER_RAISE = 0.002; // the face lifts 2mm toward the finger on hover
+const FACE_REST_Y = -0.003; // face sits 3mm under the hitbox center
+
+/**
+ * A minimal poke button mirroring the contract of webapp's OrnamentButton:
+ * a wide-thin invisible hitbox (thinnest axis = press axis) is what the
+ * poke pipeline probes; the visible face raises on hover, would squeeze on
+ * a controller press but skips the squeeze for fingertip pokes (the finger
+ * occludes the button), and fires onClick when a press releases.
+ */
+interface PokeButton {
+    hitBox: Mesh;
+    face: Mesh;
+    clicks: number;
+    squeezes: number;
+}
+
+const createPokeButton = (
+    scene: Scene,
+    name: string,
+    parent: TransformNode,
+    positionX: number
+): PokeButton => {
+    // Unit box scaled to 40mm x 1mm x 40mm: Y is the thinnest axis, so the
+    // poke geometry treats world Y as the press axis.
+    const hitBox = MeshBuilder.CreateBox(`${name}HitBox`, { size: 1 }, scene);
+    hitBox.scaling = new Vector3(0.04, 0.001, 0.04);
+    hitBox.position = new Vector3(positionX, 0, 0);
+    hitBox.rotationQuaternion = Quaternion.Identity();
+    hitBox.isVisible = false;
+    hitBox.parent = parent;
+
+    const face = MeshBuilder.CreateBox(
+        `${name}Face`,
+        { width: 0.036, height: 0.001, depth: 0.036 },
+        scene
+    );
+    face.position = new Vector3(positionX, FACE_REST_Y, 0);
+    face.parent = parent;
+
+    hitBox.computeWorldMatrix(true);
+    face.computeWorldMatrix(true);
+
+    const button: PokeButton = { hitBox, face, clicks: 0, squeezes: 0 };
+
+    let primed = false;
+    scene.onPointerObservable.add((pointerInfo: PointerInfo) => {
+        const isOwnPick = pointerInfo.pickInfo?.pickedMesh === hitBox;
+        const pointerType = (
+            pointerInfo.event as unknown as { pointerType?: string }
+        ).pointerType;
+
+        switch (pointerInfo.type) {
+            case PointerEventTypes.POINTERMOVE:
+                // One move drives hover-in on the picked button and
+                // hover-out on every other (a null pick lowers them all).
+                // Hover-out does NOT cancel a primed press — the state
+                // machine completes every press with an `up` on the pressed
+                // mesh (including on tracking loss), and the click fires
+                // there.
+                face.position.y = isOwnPick
+                    ? FACE_REST_Y + HOVER_RAISE
+                    : FACE_REST_Y;
+                break;
+            case PointerEventTypes.POINTERDOWN:
+                if (isOwnPick) {
+                    primed = true;
+                    // A laser/controller press squeezes the face for 1:1
+                    // trigger feel; a fingertip occludes the button, so
+                    // poke-tagged presses skip the animation.
+                    if (pointerType !== POKE_POINTER_TYPE) {
+                        button.squeezes += 1;
+                    }
+                }
+                break;
+            case PointerEventTypes.POINTERUP:
+                if (isOwnPick && primed) {
+                    primed = false;
+                    button.clicks += 1;
+                }
+                break;
+        }
+    });
+
+    return button;
+};
+
+describe('hand menu example: poking buttons with a tracked fingertip', () => {
+    let engine: Engine;
+    let scene: Scene;
+    let menuRoot: TransformNode;
+    let playButton: PokeButton;
+    let exitButton: PokeButton;
+    let hand: WebXRHand;
+    let fingerTip: Mesh;
+    let hitboxes: Set<AbstractMesh>;
+    let mem: PokeMemory;
+    let now: number;
+
+    beforeAll(() => {
+        engine = new NullEngine();
+    });
+
+    beforeEach(() => {
+        scene = new Scene(engine);
+        now = 0;
+        mem = createPokeMemory();
+
+        // Stands in for the headset camera a real XR session provides;
+        // scene.render() requires one.
+        new FreeCamera('headset', new Vector3(0, 0.2, -0.3), scene);
+
+        // The menu node. On device this is where HandConstraintBehavior
+        // attaches (palm-up visibility); headlessly we just place it, and
+        // palm gating reduces to setEnabled — which pokeFrame honors.
+        menuRoot = new TransformNode('handMenu', scene);
+
+        // Two buttons, like a play/exit pair on the menu's front face. A
+        // registry of hitboxes keeps the per-frame probe to a handful of
+        // meshes instead of the whole scene.
+        playButton = createPokeButton(scene, 'play', menuRoot, 0);
+        exitButton = createPokeButton(scene, 'exit', menuRoot, 0.06);
+        hitboxes = new Set([playButton.hitBox, exitButton.hitBox]);
+
+        // A mock tracked hand: the index fingertip is just a mesh the test
+        // moves around; getJointMesh resolves it the way a real WebXRHand
+        // would.
+        fingerTip = MeshBuilder.CreateSphere(
+            'fingerTip',
+            { diameter: 0.008 },
+            scene
+        );
+        // Park the finger well away from the menu so nothing is hovered or
+        // pressed until a test moves it.
+        fingerTip.position.set(0, 0.5, 0);
+        fingerTip.computeWorldMatrix(true);
+        hand = createMockXrHand({ 'index-finger-tip': fingerTip });
+
+        // The app-side wiring, verbatim: once per rendered frame, read the
+        // fingertip joint and advance the poke pipeline.
+        scene.onBeforeRenderObservable.add(() => {
+            const tip = hand.getJointMesh('index-finger-tip' as never) as
+                | AbstractMesh
+                | undefined;
+            if (tip) {
+                pokeFrame(
+                    scene,
+                    tip.absolutePosition,
+                    hitboxes,
+                    mem,
+                    now,
+                    DEFAULT_POKE_THRESHOLDS
+                );
+            } else {
+                pokeRelease(scene, mem, now, DEFAULT_POKE_THRESHOLDS);
+            }
+        });
+
+        scene.render();
+    });
+
+    afterEach(() => {
+        scene.dispose();
+    });
+
+    afterAll(() => {
+        engine.dispose();
+    });
+
+    /** Move the tracked fingertip and render one frame. */
+    const trackFingerAt = (position: Vector3, dtMs = FRAME_MS) => {
+        now += dtMs;
+        fingerTip.position.copyFrom(position);
+        fingerTip.computeWorldMatrix(true);
+        scene.render();
+    };
+
+    it('clicks the poked button — and only that button', () => {
+        trackFingerAt(new Vector3(0, 0.01, 0)); // approach: hover range
+        trackFingerAt(new Vector3(0, 0, 0)); // contact: press
+        trackFingerAt(new Vector3(0, 0.01, 0)); // withdraw: release → click
+
+        expect(playButton.clicks).toBe(1);
+        expect(exitButton.clicks).toBe(0);
+    });
+
+    it('raises the face on hover and lowers it after the finger leaves, without clicking', () => {
+        trackFingerAt(new Vector3(0, 0.01, 0)); // hover only
+        expect(playButton.face.position).toEqualVector3(
+            new Vector3(0, FACE_REST_Y + HOVER_RAISE, 0)
+        );
+
+        trackFingerAt(new Vector3(0, 0.05, 0)); // leave hover range
+        expect(playButton.face.position).toEqualVector3(
+            new Vector3(0, FACE_REST_Y, 0)
+        );
+        expect(playButton.clicks).toBe(0);
+    });
+
+    it('skips the press squeeze for fingertip pokes (xr-near pointerType)', () => {
+        trackFingerAt(new Vector3(0, 0.01, 0));
+        trackFingerAt(new Vector3(0, 0, 0)); // held press
+
+        expect(playButton.squeezes).toBe(0);
+        expect(playButton.clicks).toBe(0); // no click until release
+    });
+
+    it('ignores pokes into a disabled menu face (palm-down gating)', () => {
+        // On device, HandConstraintBehavior or a front/back-face toggle
+        // disables the node; isEnabled() folds in every ancestor, so
+        // disabling the menu root gates every hitbox under it.
+        menuRoot.setEnabled(false);
+
+        trackFingerAt(new Vector3(0, 0.01, 0));
+        trackFingerAt(new Vector3(0, 0, 0));
+        trackFingerAt(new Vector3(0, 0.01, 0));
+
+        expect(playButton.clicks).toBe(0);
+        expect(playButton.face.position).toEqualVector3(
+            new Vector3(0, FACE_REST_Y, 0)
+        );
+    });
+
+    it('debounces a double-tap inside the debounce window, allows it after', () => {
+        trackFingerAt(new Vector3(0, 0.01, 0));
+        trackFingerAt(new Vector3(0, 0, 0));
+        trackFingerAt(new Vector3(0, 0.01, 0)); // click #1
+
+        // Immediate re-tap, inside the 250ms window: no second click.
+        trackFingerAt(new Vector3(0, 0, 0));
+        trackFingerAt(new Vector3(0, 0.01, 0));
+        expect(playButton.clicks).toBe(1);
+
+        // Same tap after the window passes: clicks again.
+        trackFingerAt(new Vector3(0, 0, 0), 300);
+        trackFingerAt(new Vector3(0, 0.01, 0));
+        expect(playButton.clicks).toBe(2);
+    });
+
+    it('completes the press when hand tracking drops mid-poke, with no stale re-fire', () => {
+        trackFingerAt(new Vector3(0, 0.01, 0));
+        trackFingerAt(new Vector3(0, 0, 0)); // held press
+
+        // Tracking loss: the app-side observer can no longer resolve the
+        // joint and calls pokeRelease — the held press completes its
+        // release (click) and state is left clean.
+        hand = createMockXrHand({});
+        now += FRAME_MS;
+        scene.render();
+        expect(playButton.clicks).toBe(1);
+
+        // The hand re-tracks with the finger already withdrawn, outside the
+        // debounce window: no stale second release.
+        hand = createMockXrHand({ 'index-finger-tip': fingerTip });
+        trackFingerAt(new Vector3(0, 0.01, 0), 400);
+        expect(playButton.clicks).toBe(1);
+    });
+
+    it('the menu is queryable like any other scene content', () => {
+        expect(getByMeshName(scene, 'playHitBox')).toEqual(playButton.hitBox);
+        expect(getByMeshName(scene, 'exitFace')).toEqual(exitButton.face);
+    });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,6 @@ export * from './waitOrAdvance';
 export * from './mesh-events';
 export * from './xrMocks';
 export * from './matchers';
+export * from './pokeGeometry';
+export * from './pokeStateMachine';
+export * from './pokeEmitter';

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,6 @@ export * from './event';
 export * from './query-helpers';
 export * from './realTimeWaits';
 export * from './waitOrAdvance';
+export * from './mesh-events';
+export * from './xrMocks';
+export * from './matchers';

--- a/src/matchers.spec.ts
+++ b/src/matchers.spec.ts
@@ -1,0 +1,70 @@
+import { Color3, Color4, Matrix, Quaternion, Vector3 } from '@babylonjs/core';
+import { babylonMatchers, setupBabylonExpect } from './matchers';
+
+setupBabylonExpect();
+
+describe('babylon matchers', () => {
+    it('registers all five matchers', () => {
+        expect(Object.keys(babylonMatchers).sort()).toEqual([
+            'toEqualColor3',
+            'toEqualColor4',
+            'toEqualMatrix',
+            'toEqualQuaternion',
+            'toEqualVector3',
+        ]);
+    });
+
+    it('toEqualVector3 passes for equal vectors', () => {
+        expect(new Vector3(1, 2, 3)).toEqualVector3(new Vector3(1, 2, 3));
+    });
+
+    it('toEqualVector3 fails for different vectors with a readable message', () => {
+        expect(() =>
+            expect(new Vector3(1, 2, 3)).toEqualVector3(new Vector3(4, 5, 6))
+        ).toThrow(/Expected:.*4.*5.*6/s);
+    });
+
+    it('toEqualVector3 supports epsilon comparison', () => {
+        expect(new Vector3(1.0001, 2, 3)).toEqualVector3(
+            new Vector3(1, 2, 3),
+            0.01
+        );
+        expect(() =>
+            expect(new Vector3(1.0001, 2, 3)).toEqualVector3(
+                new Vector3(1, 2, 3),
+                0.00001
+            )
+        ).toThrow();
+    });
+
+    it('rejects values of the wrong type', () => {
+        expect(() =>
+            expect('not a vector').toEqualVector3(new Vector3(1, 2, 3))
+        ).toThrow('Expected received value to be a Vector3');
+        expect(() =>
+            expect(new Vector3(1, 2, 3)).toEqualVector3(
+                'not a vector' as unknown as Vector3
+            )
+        ).toThrow('Expected expected value to be a Vector3');
+    });
+
+    it('toEqualQuaternion compares quaternions', () => {
+        expect(Quaternion.Identity()).toEqualQuaternion(Quaternion.Identity());
+    });
+
+    it('toEqualMatrix compares matrices', () => {
+        expect(Matrix.Identity()).toEqualMatrix(Matrix.Identity());
+        expect(() =>
+            expect(Matrix.Identity()).toEqualMatrix(Matrix.Zero())
+        ).toThrow();
+    });
+
+    it('toEqualColor3 and toEqualColor4 compare colors', () => {
+        expect(new Color3(0.5, 0.5, 0.5)).toEqualColor3(
+            new Color3(0.5, 0.5, 0.5)
+        );
+        expect(new Color4(0.1, 0.2, 0.3, 1)).toEqualColor4(
+            new Color4(0.1, 0.2, 0.3, 1)
+        );
+    });
+});

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -1,0 +1,104 @@
+import { Color3, Color4, Matrix, Quaternion, Vector3 } from '@babylonjs/core';
+
+/**
+ * Babylon-aware jest matchers: structural equality via Babylon's own
+ * equals/equalsWithEpsilon, with readable failure output. Register them once
+ * per test environment (e.g. in a jest setup file):
+ *
+ *     import { setupBabylonExpect } from 'babylon-testing-library';
+ *     setupBabylonExpect();
+ *
+ * or pass the raw map to your runner: `expect.extend(babylonMatchers)`.
+ */
+type MatcherResult = { pass: boolean; message: () => string };
+
+type MatcherContextLike = {
+    utils?: {
+        diff?: (expected: unknown, received: unknown) => string | null;
+    };
+};
+
+type BabylonEquatable<T> = {
+    equals(other: T): boolean;
+    equalsWithEpsilon(other: T, epsilon: number): boolean;
+    toString(): string;
+};
+
+const buildMatcher = <T extends BabylonEquatable<T>>(
+    babylonClass: new (...args: never[]) => T,
+    className: string
+) => {
+    return function (
+        this: MatcherContextLike,
+        received: unknown,
+        expected: unknown,
+        epsilon?: number
+    ): MatcherResult {
+        if (!(received instanceof babylonClass)) {
+            throw new Error(
+                `Expected received value to be a ${className}, but got: ${received}`
+            );
+        }
+
+        if (!(expected instanceof babylonClass)) {
+            throw new Error(
+                `Expected expected value to be a ${className}, but got: ${expected}`
+            );
+        }
+
+        const pass =
+            epsilon !== undefined
+                ? received.equalsWithEpsilon(expected, epsilon)
+                : received.equals(expected);
+
+        const message = () => {
+            const diff = this?.utils?.diff?.(expected, received);
+            return `Expected: ${expected.toString()}\nReceived: ${received.toString()}${
+                diff ? `\n\n${diff}` : ''
+            }`;
+        };
+
+        return { pass, message };
+    };
+};
+
+export const babylonMatchers = {
+    toEqualVector3: buildMatcher(Vector3, 'Vector3'),
+    toEqualQuaternion: buildMatcher(Quaternion, 'Quaternion'),
+    toEqualMatrix: buildMatcher(Matrix, 'Matrix'),
+    toEqualColor3: buildMatcher(Color3, 'Color3'),
+    toEqualColor4: buildMatcher(Color4, 'Color4'),
+};
+
+// The test runner's expect global; typed structurally so this module carries
+// no jest type dependency into consumers.
+declare const expect:
+    | { extend: (matchers: Record<string, unknown>) => void }
+    | undefined;
+
+/** Registers the Babylon matchers with the ambient `expect` global. */
+export const setupBabylonExpect = () => {
+    if (typeof expect === 'undefined') {
+        throw new Error(
+            'setupBabylonExpect requires a global `expect` (run it inside your test environment)'
+        );
+    }
+    expect.extend(babylonMatchers);
+};
+
+declare global {
+    // Merges with @types/jest's Matchers when present; declares a fresh,
+    // harmless namespace otherwise.
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    namespace jest {
+        // The type parameter list must match @types/jest's declaration.
+        // eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-unused-vars
+        interface Matchers<R = void, T = {}> {
+            toEqualVector3(expected: Vector3, epsilon?: number): R;
+            toEqualQuaternion(expected: Quaternion, epsilon?: number): R;
+            toEqualMatrix(expected: Matrix, epsilon?: number): R;
+            toEqualColor3(expected: Color3, epsilon?: number): R;
+            toEqualColor4(expected: Color4, epsilon?: number): R;
+        }
+    }
+}

--- a/src/mesh-events.spec.ts
+++ b/src/mesh-events.spec.ts
@@ -1,0 +1,139 @@
+import {
+    Engine,
+    FreeCamera,
+    Matrix,
+    Mesh,
+    MeshBuilder,
+    NullEngine,
+    PointerEventTypes,
+    PointerInfo,
+    Scene,
+    Vector3,
+} from '@babylonjs/core';
+import {
+    clickMesh,
+    fireMeshPointer,
+    getPickInfo,
+    hoverMesh,
+    pickThinInstance,
+} from './mesh-events';
+
+describe('mesh events', () => {
+    let scene: Scene, engine: Engine, button: Mesh;
+
+    beforeAll(() => {
+        engine = new NullEngine();
+    });
+
+    beforeEach(() => {
+        scene = new Scene(engine);
+        new FreeCamera('camera', new Vector3(0, 0, -5), scene);
+        button = MeshBuilder.CreateBox('button', { size: 1 }, scene);
+    });
+
+    afterEach(() => {
+        scene.dispose();
+    });
+
+    afterAll(() => {
+        engine.dispose();
+    });
+
+    it('clickMesh fires pointer down then pointer up with a real pick of the mesh', async () => {
+        const received: PointerInfo[] = [];
+        scene.onPointerObservable.add((pointerInfo) => {
+            received.push(pointerInfo);
+        });
+
+        const pickInfo = await clickMesh(scene, button);
+
+        expect(received.map((info) => info.type)).toEqual([
+            PointerEventTypes.POINTERDOWN,
+            PointerEventTypes.POINTERUP,
+        ]);
+        expect(pickInfo.pickedMesh).toEqual(button);
+        expect(received[0].pickInfo?.pickedMesh).toEqual(button);
+    });
+
+    it('fireMeshPointer can fire a single pointer up (no down)', async () => {
+        const received: PointerInfo[] = [];
+        scene.onPointerObservable.add((pointerInfo) => {
+            received.push(pointerInfo);
+        });
+
+        await fireMeshPointer(scene, button, PointerEventTypes.POINTERUP);
+
+        expect(received.map((info) => info.type)).toEqual([
+            PointerEventTypes.POINTERUP,
+        ]);
+    });
+
+    it('hoverMesh fires a pointer move over the mesh', async () => {
+        const received: PointerInfo[] = [];
+        scene.onPointerObservable.add((pointerInfo) => {
+            received.push(pointerInfo);
+        });
+
+        await hoverMesh(scene, button);
+
+        expect(received.map((info) => info.type)).toEqual([
+            PointerEventTypes.POINTERMOVE,
+        ]);
+    });
+
+    it('tags the synthesized event with the requested pointerType', async () => {
+        const received: PointerInfo[] = [];
+        scene.onPointerObservable.add((pointerInfo) => {
+            received.push(pointerInfo);
+        });
+
+        await fireMeshPointer(scene, button, PointerEventTypes.POINTERUP, {
+            pointerType: 'xr-near',
+        });
+
+        const event = received[0].event as unknown as {
+            pointerType?: string;
+        };
+        expect(event.pointerType).toEqual('xr-near');
+    });
+
+    it('accepts an explicit ray origin', async () => {
+        const pickInfo = await getPickInfo(scene, button, {
+            origin: new Vector3(0, 0, 3),
+        });
+        expect(pickInfo.pickedMesh).toEqual(button);
+    });
+
+    it('re-renders and recomputes the pick target on every retry', async () => {
+        button.position.set(2, 1, 0);
+
+        const pickInfo = await getPickInfo(scene, button);
+        expect(pickInfo.pickedMesh).toEqual(button);
+    });
+
+    it('rejects with the pick failure when the mesh cannot be picked', async () => {
+        button.isPickable = false;
+
+        await expect(
+            getPickInfo(scene, button, { timeout: 150, interval: 25 })
+        ).rejects.toThrow('Expected to pick button, but picked: nothing');
+    });
+
+    it('pickThinInstance picks a specific thin instance', async () => {
+        // thinInstanceAdd is gated on engine instancedArrays support (absent
+        // under NullEngine); thinInstanceSetBuffer is plain data and works.
+        button.thinInstanceEnablePicking = true;
+        const matrices = new Float32Array(32);
+        Matrix.Translation(0, 0, 0).copyToArray(matrices, 0);
+        Matrix.Translation(2.5, 0, 0).copyToArray(matrices, 16);
+        button.thinInstanceSetBuffer('matrix', matrices, 16);
+        scene.render();
+
+        const pickInfo = pickThinInstance(scene, button, 1, {
+            origin: new Vector3(2.5, 0, -5),
+        });
+
+        expect(pickInfo?.pickedMesh).toEqual(button);
+        expect(pickInfo?.thinInstanceIndex).toEqual(1);
+    });
+});

--- a/src/mesh-events.ts
+++ b/src/mesh-events.ts
@@ -1,0 +1,183 @@
+import {
+    AbstractMesh,
+    Mesh,
+    Nullable,
+    PickingInfo,
+    PointerEventTypes,
+    PointerInfo,
+    Ray,
+    Scene,
+    Vector3,
+} from '@babylonjs/core';
+import { RealTimeWaitOptions, waitForRealTime } from './realTimeWaits';
+
+/**
+ * Pointer simulation for 3D meshes. GUI controls receive events through
+ * their own observables (see fireEvent), but mesh interactions in Babylon
+ * flow through `scene.onPointerObservable` with a `PickingInfo` — these
+ * helpers perform a real ray pick against the mesh and then notify the scene
+ * observable, exactly as Babylon's input layer would.
+ */
+export interface MeshPickOptions extends RealTimeWaitOptions {
+    /**
+     * Ray origin for the pick. Defaults to the active camera's position,
+     * falling back to the world origin (pass an explicit origin for
+     * camera-less NullEngine scenes with meshes at the origin).
+     */
+    origin?: Vector3;
+    /**
+     * Pick predicate. Defaults to the target mesh itself, honoring
+     * isPickable/isEnabled/isVisible the way Babylon's default pick
+     * predicate does. Note that per Babylon semantics an explicit filter
+     * REPLACES those checks rather than adding to them.
+     */
+    filter?: (mesh: AbstractMesh) => boolean;
+}
+
+export interface MeshPointerEventOptions extends MeshPickOptions {
+    /**
+     * `pointerType` tag for the synthesized DOM event (e.g. 'xr-near' for
+     * near-interaction pokes); components can branch on it the way Babylon's
+     * WebXR input does.
+     */
+    pointerType?: string;
+}
+
+const resolveOrigin = (scene: Scene, origin?: Vector3): Vector3 =>
+    origin ?? scene.activeCamera?.globalPosition ?? Vector3.Zero();
+
+/**
+ * Ray-picks the given mesh, rendering the scene and recomputing the pick
+ * target inside every retry — world matrices (including thin instances) may
+ * not have settled yet, and a stale target is a classic source of pick
+ * flakes under CI load. The wait is enforced in real elapsed time, so this
+ * stays correct under jest fake timers.
+ */
+export const getPickInfo = (
+    scene: Scene,
+    mesh: AbstractMesh,
+    options: MeshPickOptions = {}
+): Promise<PickingInfo> => {
+    const {
+        origin,
+        filter = (candidate: AbstractMesh) =>
+            candidate === mesh &&
+            candidate.isPickable &&
+            candidate.isEnabled() &&
+            candidate.isVisible,
+        ...waitOptions
+    } = options;
+
+    return waitForRealTime(() => {
+        scene.render();
+        const rayOrigin = resolveOrigin(scene, origin);
+        const target = mesh.absolutePosition;
+        const pickInfo = scene.pickWithRay(
+            new Ray(rayOrigin, target.subtract(rayOrigin)),
+            filter
+        );
+
+        if (pickInfo?.pickedMesh !== mesh) {
+            throw new Error(
+                `Expected to pick ${mesh.name}, but picked: ${pickInfo?.pickedMesh?.name ?? 'nothing'}`
+            );
+        }
+
+        return pickInfo;
+    }, waitOptions);
+};
+
+const DOM_TYPE_BY_POINTER_EVENT: Partial<Record<number, string>> = {
+    [PointerEventTypes.POINTERDOWN]: 'pointerdown',
+    [PointerEventTypes.POINTERUP]: 'pointerup',
+    [PointerEventTypes.POINTERMOVE]: 'pointermove',
+};
+
+const synthesizePointerEvent = (
+    type: number,
+    pointerType?: string
+): MouseEvent => {
+    const event = new MouseEvent(
+        DOM_TYPE_BY_POINTER_EVENT[type] ?? 'pointermove'
+    );
+    if (pointerType !== undefined) {
+        // jsdom's MouseEvent has no pointerType; tag it the way Babylon's
+        // WebXR near-interaction layer tags its synthesized events.
+        Object.defineProperty(event, 'pointerType', { value: pointerType });
+    }
+    return event;
+};
+
+/**
+ * Picks the mesh, then notifies `scene.onPointerObservable` once per given
+ * pointer event type (`PointerEventTypes` constants, in order), sharing one
+ * `PickingInfo`. Returns it.
+ */
+export const fireMeshPointer = async (
+    scene: Scene,
+    mesh: AbstractMesh,
+    types: number | number[],
+    options: MeshPointerEventOptions = {}
+): Promise<PickingInfo> => {
+    const { pointerType, ...pickOptions } = options;
+    const pickInfo = await getPickInfo(scene, mesh, pickOptions);
+
+    const typeList = Array.isArray(types) ? types : [types];
+    for (const type of typeList) {
+        scene.onPointerObservable.notifyObservers(
+            new PointerInfo(
+                type,
+                synthesizePointerEvent(type, pointerType),
+                pickInfo
+            )
+        );
+    }
+
+    return pickInfo;
+};
+
+/** Pointer down followed by pointer up on the mesh — a full click. */
+export const clickMesh = (
+    scene: Scene,
+    mesh: AbstractMesh,
+    options: MeshPointerEventOptions = {}
+): Promise<PickingInfo> =>
+    fireMeshPointer(
+        scene,
+        mesh,
+        [PointerEventTypes.POINTERDOWN, PointerEventTypes.POINTERUP],
+        options
+    );
+
+/** A single pointer move over the mesh — drives hover behaviors. */
+export const hoverMesh = (
+    scene: Scene,
+    mesh: AbstractMesh,
+    options: MeshPointerEventOptions = {}
+): Promise<PickingInfo> =>
+    fireMeshPointer(scene, mesh, PointerEventTypes.POINTERMOVE, options);
+
+/**
+ * Ray-picks a specific thin instance of a mesh by decomposing the instance's
+ * world matrix into a pick target. Returns Babylon's raw pick result.
+ */
+export const pickThinInstance = (
+    scene: Scene,
+    mesh: Mesh,
+    index: number,
+    options: Pick<MeshPickOptions, 'origin'> = {}
+): Nullable<PickingInfo> => {
+    const origin = resolveOrigin(scene, options.origin);
+    const matrices = mesh.thinInstanceGetWorldMatrices();
+    const transform = matrices[index];
+    if (!transform) {
+        throw new Error(
+            `Mesh ${mesh.name} has no thin instance at index ${index} (found ${matrices.length})`
+        );
+    }
+    const position = Vector3.Zero();
+    transform.decompose(undefined, undefined, position);
+    position.addInPlace(mesh.absolutePosition);
+
+    return scene.pickWithRay(new Ray(origin, position.subtract(origin)));
+};

--- a/src/pokeEmitter.spec.ts
+++ b/src/pokeEmitter.spec.ts
@@ -1,0 +1,220 @@
+import {
+    Engine,
+    Mesh,
+    MeshBuilder,
+    NullEngine,
+    PointerEventTypes,
+    PointerInfo,
+    Quaternion,
+    Scene,
+    Vector3,
+} from '@babylonjs/core';
+import { POKE_POINTER_TYPE, pokeFrame, pokeRelease } from './pokeEmitter';
+import {
+    createPokeMemory,
+    DEFAULT_POKE_THRESHOLDS,
+    PokeMemory,
+} from './pokeStateMachine';
+
+const T = DEFAULT_POKE_THRESHOLDS;
+
+describe('pokeFrame / pokeRelease', () => {
+    let engine: Engine;
+    let scene: Scene;
+    let hitBox: Mesh;
+    let mem: PokeMemory;
+    let received: PointerInfo[];
+
+    beforeAll(() => {
+        engine = new NullEngine();
+    });
+
+    beforeEach(() => {
+        mem = createPokeMemory();
+        scene = new Scene(engine);
+        received = [];
+        scene.onPointerObservable.add((pointerInfo) => {
+            received.push(pointerInfo);
+        });
+
+        // A real menu button hitbox: wide (40mm) in X/Z, thin (1mm) in Y →
+        // the finger pokes along world Y.
+        hitBox = MeshBuilder.CreateBox('hitBox', { size: 1 }, scene);
+        hitBox.scaling = new Vector3(0.04, 0.001, 0.04);
+        hitBox.rotationQuaternion = Quaternion.Identity();
+        hitBox.computeWorldMatrix(true);
+    });
+
+    afterEach(() => {
+        scene.dispose();
+    });
+
+    afterAll(() => {
+        engine.dispose();
+    });
+
+    const poke = (finger: Vector3, nowMs: number) =>
+        pokeFrame(scene, finger, [hitBox], mem, nowMs, T);
+
+    const types = () => received.map((pointerInfo) => pointerInfo.type);
+
+    it('emits move, down, then up as the finger pokes in and withdraws', () => {
+        poke(new Vector3(0, 0.01, 0), 0); // hover
+        poke(new Vector3(0, 0, 0), 16); // press (reaches the face)
+        poke(new Vector3(0, 0.01, 0), 32); // withdraw → release
+
+        expect(types()).toEqual([
+            PointerEventTypes.POINTERMOVE,
+            PointerEventTypes.POINTERDOWN,
+            PointerEventTypes.POINTERUP,
+        ]);
+        for (const pointerInfo of received) {
+            expect(pointerInfo.pickInfo?.hit).toBe(true);
+            expect(pointerInfo.pickInfo?.pickedMesh).toEqual(hitBox);
+        }
+    });
+
+    it('tags every synthetic event with the xr-near pointerType', () => {
+        poke(new Vector3(0, 0.01, 0), 0);
+        poke(new Vector3(0, 0, 0), 16);
+
+        const events = received.map(
+            (pointerInfo) =>
+                pointerInfo.event as unknown as { pointerType?: string }
+        );
+        expect(events.length).toBeGreaterThanOrEqual(2);
+        for (const event of events) {
+            expect(event.pointerType).toEqual(POKE_POINTER_TYPE);
+        }
+    });
+
+    it('drives a down/up click consumer exactly once per poke', () => {
+        // Minimal mesh-button pipeline: primed by down on the hitbox,
+        // clicking on the following up — the contract OrnamentButton-style
+        // components consume.
+        let primed = false;
+        let clicks = 0;
+        scene.onPointerObservable.add((pointerInfo) => {
+            if (pointerInfo.pickInfo?.pickedMesh !== hitBox) {
+                return;
+            }
+            if (pointerInfo.type === PointerEventTypes.POINTERDOWN) {
+                primed = true;
+            } else if (
+                pointerInfo.type === PointerEventTypes.POINTERUP &&
+                primed
+            ) {
+                primed = false;
+                clicks += 1;
+            }
+        });
+
+        poke(new Vector3(0, 0.01, 0), 0);
+        poke(new Vector3(0, 0, 0), 16);
+        poke(new Vector3(0, 0.01, 0), 32);
+
+        expect(clicks).toEqual(1);
+    });
+
+    it('emits nothing when the finger stays laterally off the button face', () => {
+        // 30mm off-centre in X: outside the 20mm half-face + 4mm margin.
+        poke(new Vector3(0.03, 0.01, 0), 0);
+        poke(new Vector3(0.03, 0, 0), 16);
+        poke(new Vector3(0.03, 0.01, 0), 32);
+
+        expect(received).toEqual([]);
+    });
+
+    it('debounces a second poke within the debounce window', () => {
+        poke(new Vector3(0, 0.01, 0), 0);
+        poke(new Vector3(0, 0, 0), 16);
+        poke(new Vector3(0, 0.01, 0), 32); // release #1 at t=32
+
+        const afterFirstPoke = types();
+
+        // immediate re-poke inside the 250ms window must not press again
+        poke(new Vector3(0, 0, 0), 60);
+        poke(new Vector3(0, 0.01, 0), 80);
+        expect(types()).toEqual(afterFirstPoke);
+
+        // ...but a poke after the window presses again
+        poke(new Vector3(0, 0, 0), 320);
+        expect(types()).toEqual([
+            ...afterFirstPoke,
+            PointerEventTypes.POINTERDOWN,
+        ]);
+    });
+
+    it('skips disabled hitboxes entirely', () => {
+        // isEnabled() folds in every ancestor: palm/gaze gates and face
+        // toggles gate pokes exactly as they gate rendering. A poke into a
+        // disabled hitbox must do nothing.
+        hitBox.setEnabled(false);
+
+        poke(new Vector3(0, 0.01, 0), 0);
+        poke(new Vector3(0, 0, 0), 16);
+        poke(new Vector3(0, 0.01, 0), 32);
+
+        expect(received).toEqual([]);
+    });
+
+    it('targets the nearest in-face hitbox when several are in range', () => {
+        const nearer = MeshBuilder.CreateBox('nearer', { size: 1 }, scene);
+        nearer.scaling = new Vector3(0.04, 0.001, 0.04);
+        nearer.position = new Vector3(0, 0.005, 0);
+        nearer.rotationQuaternion = Quaternion.Identity();
+        nearer.computeWorldMatrix(true);
+
+        pokeFrame(
+            scene,
+            new Vector3(0, 0.0065, 0),
+            [hitBox, nearer],
+            mem,
+            0,
+            T
+        );
+
+        expect(types()).toEqual([PointerEventTypes.POINTERMOVE]);
+        expect(received[0].pickInfo?.pickedMesh).toEqual(nearer);
+    });
+
+    it('pokeRelease while only hovering clears state with a hover-out and no click', () => {
+        poke(new Vector3(0, 0.01, 0), 0); // hover, no press
+
+        pokeRelease(scene, mem, 16, T); // hand tracking drops the fingertip
+
+        expect(mem.hoverMesh).toBeNull();
+        expect(mem.pressed).toBe(false);
+        expect(types()).toEqual([
+            PointerEventTypes.POINTERMOVE, // hover-in
+            PointerEventTypes.POINTERMOVE, // hover-out (null pick)
+        ]);
+        expect(received[1].pickInfo?.hit).toBe(false);
+        expect(received[1].pickInfo?.pickedMesh).toBeNull();
+    });
+
+    it('pokeRelease on a held press releases once; a re-tracked frame adds no stale release', () => {
+        poke(new Vector3(0, 0.01, 0), 0); // hover
+        poke(new Vector3(0, 0, 0), 16); // press (down)
+
+        // Hand tracking drops the fingertip mid-press: the press completes
+        // its release now...
+        pokeRelease(scene, mem, 32, T);
+        expect(types()).toEqual([
+            PointerEventTypes.POINTERMOVE,
+            PointerEventTypes.POINTERDOWN,
+            PointerEventTypes.POINTERMOVE, // hover-out
+            PointerEventTypes.POINTERUP,
+        ]);
+        expect(mem.pressed).toBe(false);
+        expect(mem.pressedMesh).toBeNull();
+
+        // ...and the re-tracked frame (finger already withdrawn, outside the
+        // debounce window) must NOT fire a second, stale release.
+        const afterRelease = types();
+        poke(new Vector3(0, 0.01, 0), 400);
+        // a hover-in move is fine; no down/up may appear
+        const newEvents = types().slice(afterRelease.length);
+        expect(newEvents).toEqual([PointerEventTypes.POINTERMOVE]);
+    });
+});

--- a/src/pokeEmitter.ts
+++ b/src/pokeEmitter.ts
@@ -1,0 +1,145 @@
+import {
+    AbstractMesh,
+    PickingInfo,
+    PointerEventTypes,
+    PointerInfo,
+    Scene,
+    Vector3,
+} from '@babylonjs/core';
+import { PokeProbe, probePoke } from './pokeGeometry';
+import {
+    DEFAULT_POKE_THRESHOLDS,
+    PokeCandidate,
+    PokeEmitType,
+    PokeMemory,
+    PokeThresholds,
+    stepPoke,
+} from './pokeStateMachine';
+
+/** Lateral finger radius (m) added to the button face so a slightly-off poke still lands. */
+export const POKE_LATERAL_MARGIN = 0.004;
+
+/**
+ * pointerType tag on the synthetic events injected by the poke emitter, so
+ * global `scene.onPointerObservable` consumers (e.g. world-selection
+ * handlers) can recognise and ignore them — and buttons can skip
+ * press-squeeze animations that make no sense when a fingertip occludes the
+ * button.
+ */
+export const POKE_POINTER_TYPE = 'xr-near';
+
+const EMIT_TYPE_TO_POINTER_EVENT: Record<PokeEmitType, number> = {
+    move: PointerEventTypes.POINTERMOVE,
+    down: PointerEventTypes.POINTERDOWN,
+    up: PointerEventTypes.POINTERUP,
+};
+
+// scratch — reused across frames
+const _probe: PokeProbe = {
+    approachGap: Number.POSITIVE_INFINITY,
+    inFace: false,
+};
+const _candidate: PokeCandidate = {
+    hitbox: null as unknown as AbstractMesh,
+    approachGap: 0,
+};
+
+let _nearEvent: MouseEvent | undefined;
+function nearPointerEvent(): MouseEvent {
+    if (!_nearEvent) {
+        // MouseEvent carries no pointerType; tag one so consumers can filter
+        // poke-synthesized events.
+        _nearEvent = new MouseEvent('pointermove');
+        Object.defineProperty(_nearEvent, 'pointerType', {
+            value: POKE_POINTER_TYPE,
+        });
+    }
+    return _nearEvent;
+}
+
+function emitPointer(
+    scene: Scene,
+    type: PokeEmitType,
+    mesh: AbstractMesh | null
+): void {
+    const pickInfo = new PickingInfo();
+    if (mesh) {
+        pickInfo.hit = true;
+        pickInfo.pickedMesh = mesh;
+    }
+    scene.onPointerObservable.notifyObservers(
+        new PointerInfo(
+            EMIT_TYPE_TO_POINTER_EVENT[type],
+            nearPointerEvent(),
+            pickInfo
+        )
+    );
+}
+
+/**
+ * Run one poke frame: pick the hitbox the fingertip is closest to (in-face
+ * and within hover range), advance the state machine, and inject the
+ * resulting Babylon pointer events into the scene so a mesh-button pipeline
+ * reacts exactly as it would to a controller pointer. Disabled hitboxes are
+ * skipped — `isEnabled()` folds in every ancestor, so palm/gaze gates and
+ * face toggles gate pokes the same way they gate rendering.
+ *
+ * Allocation-free on steady frames; only hover/press transitions construct
+ * events (rare).
+ */
+export function pokeFrame(
+    scene: Scene,
+    fingerTipWorld: Vector3,
+    hitboxes: Iterable<AbstractMesh>,
+    mem: PokeMemory,
+    nowMs: number,
+    thresholds: PokeThresholds = DEFAULT_POKE_THRESHOLDS
+): void {
+    let candidate: PokeCandidate | null = null;
+
+    for (const hitbox of hitboxes) {
+        if (!hitbox.isEnabled()) {
+            continue;
+        }
+        probePoke(
+            fingerTipWorld,
+            hitbox.getWorldMatrix(),
+            POKE_LATERAL_MARGIN,
+            _probe
+        );
+        if (!_probe.inFace || _probe.approachGap > thresholds.hoverApproach) {
+            continue;
+        }
+        if (candidate === null || _probe.approachGap < candidate.approachGap) {
+            _candidate.hitbox = hitbox;
+            _candidate.approachGap = _probe.approachGap;
+            candidate = _candidate;
+        }
+    }
+
+    const emits = stepPoke(mem, candidate, nowMs, thresholds);
+    for (let i = 0; i < emits.length; i++) {
+        emitPointer(scene, emits[i].type, emits[i].mesh);
+    }
+}
+
+/**
+ * End any in-progress poke because the fingertip is unavailable (hand
+ * tracking dropped the joint, or the hand left). Feeds the state machine an
+ * empty frame: a held hover emits a `move(null)` hover-out and a held press
+ * emits its `up`, then `mem` is left clean — so the button can't stay
+ * visually stuck and a later re-tracked frame can't fire a stale release
+ * against the old hitbox. Allocation-free once the state is already clear
+ * (steady tracking-loss frames emit nothing).
+ */
+export function pokeRelease(
+    scene: Scene,
+    mem: PokeMemory,
+    nowMs: number,
+    thresholds: PokeThresholds = DEFAULT_POKE_THRESHOLDS
+): void {
+    const emits = stepPoke(mem, null, nowMs, thresholds);
+    for (let i = 0; i < emits.length; i++) {
+        emitPointer(scene, emits[i].type, emits[i].mesh);
+    }
+}

--- a/src/pokeGeometry.spec.ts
+++ b/src/pokeGeometry.spec.ts
@@ -1,0 +1,97 @@
+import {
+    Engine,
+    Mesh,
+    MeshBuilder,
+    NullEngine,
+    Quaternion,
+    Scene,
+    Vector3,
+} from '@babylonjs/core';
+import { PokeProbe, probePoke } from './pokeGeometry';
+
+// Hitbox dims mirror a real menu button: wide (40mm) in X/Z, thin (1mm) in
+// Y → Y is the press axis.
+const HALF_THIN = 0.0005; // 0.5 * 0.001
+const HALF_WIDE = 0.02; // 0.5 * 0.04
+const MARGIN = 0.004;
+
+describe('probePoke', () => {
+    let engine: Engine;
+    let scene: Scene;
+    let box: Mesh;
+
+    beforeAll(() => {
+        engine = new NullEngine();
+    });
+
+    beforeEach(() => {
+        scene = new Scene(engine);
+        box = MeshBuilder.CreateBox('hitBox', { size: 1 }, scene);
+        box.scaling = new Vector3(0.04, 0.001, 0.04);
+        box.position = Vector3.Zero();
+        box.rotationQuaternion = Quaternion.Identity();
+        box.computeWorldMatrix(true);
+    });
+
+    afterEach(() => {
+        box.dispose();
+        scene.dispose();
+    });
+
+    afterAll(() => {
+        engine.dispose();
+    });
+
+    const probe = (finger: Vector3) =>
+        probePoke(finger, box.getWorldMatrix(), MARGIN);
+
+    it('reports the gap to the near face along the thin (press) axis', () => {
+        const p = probe(new Vector3(0, 0.02, 0));
+        expect(p.approachGap).toBeCloseTo(0.02 - HALF_THIN, 5);
+        expect(p.inFace).toBe(true);
+    });
+
+    it('is ~0 at the near face and negative once past it', () => {
+        expect(probe(new Vector3(0, HALF_THIN, 0)).approachGap).toBeCloseTo(
+            0,
+            5
+        );
+        expect(probe(new Vector3(0, 0, 0)).approachGap).toBeCloseTo(
+            -HALF_THIN,
+            5
+        );
+    });
+
+    it('rejects fingertips outside the wide face (beyond margin), accepts within margin', () => {
+        expect(
+            probe(new Vector3(HALF_WIDE + MARGIN + 0.002, 0.001, 0)).inFace
+        ).toBe(false);
+        expect(
+            probe(new Vector3(HALF_WIDE + MARGIN - 0.001, 0.001, 0)).inFace
+        ).toBe(true);
+    });
+
+    it('follows the oriented box under rotation (thin axis rotated onto world X)', () => {
+        box.rotationQuaternion = Quaternion.RotationAxis(
+            new Vector3(0, 0, 1),
+            Math.PI / 2
+        );
+        box.computeWorldMatrix(true);
+
+        const p = probe(new Vector3(0.02, 0, 0));
+        expect(p.approachGap).toBeCloseTo(0.02 - HALF_THIN, 5);
+        expect(p.inFace).toBe(true);
+    });
+
+    it('writes into the provided out object (allocation-free contract)', () => {
+        const out: PokeProbe = { approachGap: 0, inFace: false };
+        const result = probePoke(
+            new Vector3(0, 0.02, 0),
+            box.getWorldMatrix(),
+            MARGIN,
+            out
+        );
+        expect(result).toBe(out);
+        expect(out.approachGap).toBeCloseTo(0.02 - HALF_THIN, 5);
+    });
+});

--- a/src/pokeGeometry.ts
+++ b/src/pokeGeometry.ts
@@ -1,0 +1,84 @@
+import { Matrix, Vector3 } from '@babylonjs/core';
+
+/**
+ * Geometry for near-field "poke" interaction: project a fingertip world
+ * position into the oriented frame of a button hitbox and report how far it
+ * is from the button's near face (along the hitbox's thinnest/"press" axis)
+ * plus whether it sits within the wide face.
+ *
+ * The hitbox is a unit `CreateBox` (local extents ±0.5) carried by the
+ * menu's transform, so the world half-extents come straight from the lengths
+ * of the world-matrix axis columns. The thin axis (smallest half-extent) is
+ * the press axis; the other two are the face/lateral axes.
+ *
+ * All distances are world meters. Allocation-free: only module-scoped
+ * scratch is touched, so this is safe to call once per hitbox per frame on a
+ * 90fps render path.
+ */
+
+const LOCAL_X = new Vector3(1, 0, 0);
+const LOCAL_Y = new Vector3(0, 1, 0);
+const LOCAL_Z = new Vector3(0, 0, 1);
+
+// scratch — reused across calls, never returned
+const _center = new Vector3();
+const _rel = new Vector3();
+const _axis = new Vector3();
+
+export interface PokeProbe {
+    /**
+     * Signed distance (world meters) from the fingertip to the slab's near
+     * face along the press axis: > 0 means the fingertip is in front of the
+     * face, <= 0 means it has reached/passed it.
+     */
+    approachGap: number;
+    /** Fingertip is laterally within the wide face, expanded by `lateralMargin`. */
+    inFace: boolean;
+}
+
+/** |projection of `_rel` onto the (unit-normalized) local axis|, in world meters. */
+function absProjectionOnAxis(local: Vector3, worldMatrix: Matrix): number {
+    Vector3.TransformNormalToRef(local, worldMatrix, _axis);
+    const len = _axis.length();
+    return len === 0 ? 0 : Math.abs(Vector3.Dot(_rel, _axis) / len);
+}
+
+/** World half-extent (meters) of the unit box along the given local axis. */
+function halfExtentOnAxis(local: Vector3, worldMatrix: Matrix): number {
+    Vector3.TransformNormalToRef(local, worldMatrix, _axis);
+    return 0.5 * _axis.length();
+}
+
+export function probePoke(
+    fingerTipWorld: Vector3,
+    hitboxWorldMatrix: Matrix,
+    lateralMargin: number,
+    out: PokeProbe = { approachGap: Number.POSITIVE_INFINITY, inFace: false }
+): PokeProbe {
+    hitboxWorldMatrix.getTranslationToRef(_center);
+    fingerTipWorld.subtractToRef(_center, _rel);
+
+    const halfX = halfExtentOnAxis(LOCAL_X, hitboxWorldMatrix);
+    const halfY = halfExtentOnAxis(LOCAL_Y, hitboxWorldMatrix);
+    const halfZ = halfExtentOnAxis(LOCAL_Z, hitboxWorldMatrix);
+    const projX = absProjectionOnAxis(LOCAL_X, hitboxWorldMatrix);
+    const projY = absProjectionOnAxis(LOCAL_Y, hitboxWorldMatrix);
+    const projZ = absProjectionOnAxis(LOCAL_Z, hitboxWorldMatrix);
+
+    // press axis = thinnest (smallest half-extent); the other two bound the wide face
+    if (halfY <= halfX && halfY <= halfZ) {
+        out.approachGap = projY - halfY;
+        out.inFace =
+            projX <= halfX + lateralMargin && projZ <= halfZ + lateralMargin;
+    } else if (halfX <= halfZ) {
+        out.approachGap = projX - halfX;
+        out.inFace =
+            projY <= halfY + lateralMargin && projZ <= halfZ + lateralMargin;
+    } else {
+        out.approachGap = projZ - halfZ;
+        out.inFace =
+            projX <= halfX + lateralMargin && projY <= halfY + lateralMargin;
+    }
+
+    return out;
+}

--- a/src/pokeStateMachine.spec.ts
+++ b/src/pokeStateMachine.spec.ts
@@ -1,0 +1,87 @@
+import { AbstractMesh } from '@babylonjs/core';
+import {
+    createPokeMemory,
+    DEFAULT_POKE_THRESHOLDS,
+    PokeCandidate,
+    stepPoke,
+} from './pokeStateMachine';
+
+const T = DEFAULT_POKE_THRESHOLDS;
+
+// stepPoke only compares/relays mesh references, so plain objects stand in
+// for hitboxes.
+const buttonA = { name: 'a' } as unknown as AbstractMesh;
+const buttonB = { name: 'b' } as unknown as AbstractMesh;
+
+const cand = (hitbox: AbstractMesh, approachGap: number): PokeCandidate => ({
+    hitbox,
+    approachGap,
+});
+
+describe('stepPoke', () => {
+    it('emits a single move when the hovered hitbox changes, nothing while it stays', () => {
+        const mem = createPokeMemory();
+        expect(stepPoke(mem, cand(buttonA, 0.01), 0, T)).toEqual([
+            { type: 'move', mesh: buttonA },
+        ]);
+        expect(stepPoke(mem, cand(buttonA, 0.01), 16, T)).toEqual([]);
+    });
+
+    it('emits move(null) when the finger leaves all hitboxes', () => {
+        const mem = createPokeMemory();
+        stepPoke(mem, cand(buttonA, 0.01), 0, T);
+        expect(stepPoke(mem, null, 16, T)).toEqual([
+            { type: 'move', mesh: null },
+        ]);
+    });
+
+    it('presses at the face and releases only past the hysteresis gap', () => {
+        const mem = createPokeMemory();
+        stepPoke(mem, cand(buttonA, 0.01), 0, T); // hover
+
+        expect(stepPoke(mem, cand(buttonA, 0.0005), 16, T)).toEqual([
+            { type: 'down', mesh: buttonA },
+        ]);
+        expect(stepPoke(mem, cand(buttonA, 0.0005), 32, T)).toEqual([]); // held
+        expect(stepPoke(mem, cand(buttonA, 0.003), 48, T)).toEqual([]); // inside hysteresis band → still held
+        expect(stepPoke(mem, cand(buttonA, 0.005), 64, T)).toEqual([
+            { type: 'up', mesh: buttonA },
+        ]);
+    });
+
+    it('debounces a second press within debounceMs of release', () => {
+        const mem = createPokeMemory();
+        stepPoke(mem, cand(buttonA, 0.01), 1000, T); // hover
+        stepPoke(mem, cand(buttonA, 0.0005), 1000, T); // down
+        expect(stepPoke(mem, cand(buttonA, 0.01), 1000, T)).toEqual([
+            { type: 'up', mesh: buttonA },
+        ]);
+
+        // re-press 100ms later is blocked...
+        expect(stepPoke(mem, cand(buttonA, 0.0005), 1100, T)).toEqual([]);
+        // ...but allowed once the debounce window passes
+        expect(stepPoke(mem, cand(buttonA, 0.0005), 1300, T)).toEqual([
+            { type: 'down', mesh: buttonA },
+        ]);
+    });
+
+    it('releases (up) when the finger slides off the pressed button', () => {
+        const mem = createPokeMemory();
+        stepPoke(mem, cand(buttonA, 0.01), 0, T);
+        stepPoke(mem, cand(buttonA, 0.0005), 16, T); // down
+        expect(stepPoke(mem, null, 32, T)).toEqual([
+            { type: 'move', mesh: null },
+            { type: 'up', mesh: buttonA },
+        ]);
+    });
+
+    it('releases the old button and re-hovers when sliding onto a different one mid-press', () => {
+        const mem = createPokeMemory();
+        stepPoke(mem, cand(buttonA, 0.01), 0, T);
+        stepPoke(mem, cand(buttonA, 0.0005), 16, T); // down on A
+        expect(stepPoke(mem, cand(buttonB, 0.0005), 32, T)).toEqual([
+            { type: 'move', mesh: buttonB },
+            { type: 'up', mesh: buttonA },
+        ]);
+    });
+});

--- a/src/pokeStateMachine.ts
+++ b/src/pokeStateMachine.ts
@@ -1,0 +1,120 @@
+import { AbstractMesh } from '@babylonjs/core';
+
+/**
+ * Single-finger poke state machine. The fingertip interacts with at most one
+ * hitbox at a time (menu buttons don't overlap), so one piece of state is
+ * tracked and the Babylon pointer transitions a mesh-button pipeline
+ * consumes are emitted:
+ *
+ *   - `move` whenever the hovered hitbox changes (mesh, or `null` when the
+ *     finger leaves all of them) — one event drives hover-in on the new
+ *     button and hover-out on the rest, exactly like a real pointer pick.
+ *   - `down` when the fingertip crosses the press threshold on a button.
+ *   - `up` when it withdraws past the release threshold or leaves the
+ *     pressed button — the button fires its click.
+ *
+ * Forgiving, surface-anchored design: the press/release thresholds are close
+ * to the button face (a hand-mounted menu physically backstops the finger),
+ * with a hysteresis gap so resting at the surface can't chatter, and a
+ * per-press debounce so one poke can't double-fire.
+ */
+
+export type PokeEmitType = 'move' | 'down' | 'up';
+
+export interface PokeEmit {
+    type: PokeEmitType;
+    /** Target hitbox, or `null` for a "pointer left everything" move. */
+    mesh: AbstractMesh | null;
+}
+
+export interface PokeThresholds {
+    /** Within this distance (m) of the near face + laterally inside → hovering. */
+    hoverApproach: number;
+    /** approachGap (m) at/below which a press fires. */
+    pressGap: number;
+    /** approachGap (m) at/above which a held press releases (> pressGap → hysteresis). */
+    releaseGap: number;
+    /** Minimum ms between the end of one press and the start of the next on the same finger. */
+    debounceMs: number;
+}
+
+export const DEFAULT_POKE_THRESHOLDS: PokeThresholds = {
+    hoverApproach: 0.02,
+    pressGap: 0.001,
+    releaseGap: 0.004,
+    debounceMs: 250,
+};
+
+/** The hitbox the fingertip is closest to this frame (already filtered to in-face + in hover range). */
+export interface PokeCandidate {
+    hitbox: AbstractMesh;
+    approachGap: number;
+}
+
+export interface PokeMemory {
+    pressed: boolean;
+    hoverMesh: AbstractMesh | null;
+    pressedMesh: AbstractMesh | null;
+    lastReleaseMs: number;
+}
+
+export function createPokeMemory(): PokeMemory {
+    return {
+        pressed: false,
+        hoverMesh: null,
+        pressedMesh: null,
+        lastReleaseMs: Number.NEGATIVE_INFINITY,
+    };
+}
+
+const NO_EMITS: readonly PokeEmit[] = Object.freeze([]);
+
+/**
+ * Advance the machine by one frame. Mutates `mem` and returns the pointer
+ * events to emit (a shared frozen empty array on the common no-transition
+ * frame, so steady hover/press allocate nothing).
+ */
+export function stepPoke(
+    mem: PokeMemory,
+    candidate: PokeCandidate | null,
+    nowMs: number,
+    thresholds: PokeThresholds
+): readonly PokeEmit[] {
+    const overMesh = candidate ? candidate.hitbox : null;
+    let emits: PokeEmit[] | null = null;
+
+    // Hover change → one move reflecting the current pick (mesh or null).
+    if (overMesh !== mem.hoverMesh) {
+        mem.hoverMesh = overMesh;
+        emits = [{ type: 'move', mesh: overMesh }];
+    }
+
+    if (!mem.pressed) {
+        const debounced = nowMs - mem.lastReleaseMs < thresholds.debounceMs;
+        if (
+            candidate &&
+            candidate.approachGap <= thresholds.pressGap &&
+            !debounced
+        ) {
+            mem.pressed = true;
+            mem.pressedMesh = overMesh;
+            (emits ??= []).push({ type: 'down', mesh: overMesh });
+        }
+    } else {
+        let release: boolean;
+        if (candidate == null || candidate.hitbox !== mem.pressedMesh) {
+            release = true;
+        } else {
+            release = candidate.approachGap >= thresholds.releaseGap;
+        }
+        if (release) {
+            const releasedMesh = mem.pressedMesh;
+            mem.pressed = false;
+            mem.pressedMesh = null;
+            mem.lastReleaseMs = nowMs;
+            (emits ??= []).push({ type: 'up', mesh: releasedMesh });
+        }
+    }
+
+    return emits ?? NO_EMITS;
+}

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -1,3 +1,5 @@
 export * from './text';
 export * from './placeholder-text';
 export * from './display-value';
+export * from './name';
+export * from './mesh-name';

--- a/src/queries/mesh-name.spec.ts
+++ b/src/queries/mesh-name.spec.ts
@@ -1,0 +1,79 @@
+import {
+    AbstractMesh,
+    Engine,
+    MeshBuilder,
+    NullEngine,
+    Scene,
+} from '@babylonjs/core';
+import {
+    findByMeshName,
+    getAllByMeshName,
+    getByMeshName,
+    queryAllByMeshName,
+    queryByMeshName,
+} from './mesh-name';
+
+describe('mesh name query', () => {
+    let scene: Scene, engine: Engine, expectedMesh: AbstractMesh;
+
+    beforeAll(() => {
+        engine = new NullEngine();
+    });
+
+    beforeEach(() => {
+        scene = new Scene(engine);
+        expectedMesh = MeshBuilder.CreateBox('hitBox', { size: 1 }, scene);
+    });
+
+    afterEach(() => {
+        scene.dispose();
+    });
+
+    afterAll(() => {
+        engine.dispose();
+    });
+
+    it('should find a mesh by name', () => {
+        expect(queryByMeshName(scene, 'hitBox')).toEqual(expectedMesh);
+        expect(getByMeshName(scene, 'hitBox')).toEqual(expectedMesh);
+    });
+
+    it('should return null from queryByMeshName for a missing name', () => {
+        expect(queryByMeshName(scene, 'missing')).toEqual(null);
+    });
+
+    it('should throw a count-bearing error from getByMeshName for a missing name', () => {
+        expect(() => getByMeshName(scene, 'missing')).toThrow(
+            new Error(
+                'Unable to find a mesh with the name: missing. Scene contains 1 mesh(es)'
+            )
+        );
+    });
+
+    it('should report multiple matches', () => {
+        const duplicate = MeshBuilder.CreateBox('hitBox', { size: 1 }, scene);
+
+        expect(() => getByMeshName(scene, 'hitBox')).toThrow(
+            /Found multiple meshes with the name: hitBox/
+        );
+        expect(getAllByMeshName(scene, 'hitBox')).toEqual([
+            expectedMesh,
+            duplicate,
+        ]);
+        expect(queryAllByMeshName(scene, 'hitBox')).toHaveLength(2);
+    });
+
+    it('findByMeshName resolves when the mesh appears via a fake-clock timer', async () => {
+        jest.useFakeTimers();
+        try {
+            setTimeout(() => {
+                MeshBuilder.CreateBox('lateMesh', { size: 1 }, scene);
+            }, 3000);
+
+            const resultMesh = await findByMeshName(scene, 'lateMesh');
+            expect(resultMesh.name).toEqual('lateMesh');
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+});

--- a/src/queries/mesh-name.ts
+++ b/src/queries/mesh-name.ts
@@ -1,0 +1,35 @@
+import { AbstractMesh, Scene } from '@babylonjs/core';
+import { buildQueries } from '../query-helpers';
+
+const getMultipleError = (_scene: Scene, name: string) =>
+    `Found multiple meshes with the name: ${name}`;
+
+const getMissingError = (scene: Scene, message: string) => {
+    return `Unable to find a mesh with the name: ${message}. Scene contains ${scene.meshes.length} mesh(es)`;
+};
+
+/**
+ * Queries 3D meshes in a scene by their Babylon `name`. The findBy* variants
+ * wait in real elapsed time (fake-timer safe), which suits meshes that appear
+ * via genuinely asynchronous asset loads.
+ */
+const queryAllByMeshName = (scene: Scene, name: string): AbstractMesh[] => {
+    return scene.meshes.filter((mesh) => mesh.name === name);
+};
+
+const {
+    queryBy: queryByMeshName,
+    getAllBy: getAllByMeshName,
+    getBy: getByMeshName,
+    findAllBy: findAllByMeshName,
+    findBy: findByMeshName,
+} = buildQueries(queryAllByMeshName, getMultipleError, getMissingError);
+
+export {
+    queryAllByMeshName,
+    queryByMeshName,
+    getAllByMeshName,
+    getByMeshName,
+    findAllByMeshName,
+    findByMeshName,
+};

--- a/src/queries/name.spec.ts
+++ b/src/queries/name.spec.ts
@@ -1,0 +1,113 @@
+import { Engine, Mesh, MeshBuilder, NullEngine, Scene } from '@babylonjs/core';
+import {
+    findByName,
+    getAllByName,
+    getByName,
+    queryAllByName,
+    queryByName,
+} from './name';
+import { AdvancedDynamicTexture, Button, Grid } from '@babylonjs/gui';
+import { BabylonContainer } from './utils';
+
+describe('name query', () => {
+    let scene: Scene,
+        engine: Engine,
+        texture: AdvancedDynamicTexture,
+        containerControl: Grid,
+        expectedControl: Button,
+        uiPlane: Mesh;
+
+    beforeAll(() => {
+        engine = new NullEngine();
+    });
+
+    beforeEach(() => {
+        scene = new Scene(engine);
+
+        uiPlane = MeshBuilder.CreatePlane('container');
+        texture = AdvancedDynamicTexture.CreateForMesh(uiPlane);
+
+        containerControl = new Grid('container');
+        containerControl.addColumnDefinition(1);
+        containerControl.addColumnDefinition(1);
+        texture.addControl(containerControl);
+
+        expectedControl = Button.CreateSimpleButton('searchButton', 'Search');
+        containerControl.addControl(expectedControl, 0, 0);
+    });
+
+    afterEach(() => {
+        texture.dispose();
+        uiPlane.material?.dispose();
+        uiPlane.dispose();
+        scene.dispose();
+    });
+
+    afterAll(() => {
+        engine.dispose();
+    });
+
+    const scenarios: [string, () => BabylonContainer][] = [
+        ['a scene', () => scene],
+        ['a texture', () => texture],
+        ['a control', () => containerControl],
+    ];
+
+    describe.each(scenarios)('when querying %s', (_label, getContainer) => {
+        it('should find a control by name', () => {
+            const container = getContainer();
+            expect(queryByName(container, 'searchButton')).toEqual(
+                expectedControl
+            );
+            expect(getByName(container, 'searchButton')).toEqual(
+                expectedControl
+            );
+        });
+
+        it('should return null from queryByName for a missing name', () => {
+            expect(queryByName(getContainer(), 'missing')).toEqual(null);
+        });
+
+        it('should throw from getByName for a missing name', () => {
+            const container = getContainer();
+            expect(() => getByName(container, 'missing')).toThrow(
+                new Error(
+                    `Unable to find an element with the name: missing. Container: ${container}`
+                )
+            );
+        });
+
+        it('should throw from getByName when multiple controls share the name', () => {
+            const container = getContainer();
+            const duplicate = Button.CreateSimpleButton(
+                'searchButton',
+                'Search again'
+            );
+            containerControl.addControl(duplicate, 0, 1);
+
+            expect(() => getByName(container, 'searchButton')).toThrow(
+                /Found multiple elements with the name: searchButton/
+            );
+            expect(getAllByName(container, 'searchButton')).toHaveLength(2);
+            expect(queryAllByName(container, 'searchButton')).toEqual([
+                expectedControl,
+                duplicate,
+            ]);
+        });
+    });
+
+    it('findByName resolves when the control appears via a fake-clock timer', async () => {
+        jest.useFakeTimers();
+        try {
+            const delayed = Button.CreateSimpleButton('lateButton', 'Late');
+            setTimeout(() => {
+                containerControl.addControl(delayed, 0, 1);
+            }, 2000);
+
+            const resultControl = await findByName(scene, 'lateButton');
+            expect(resultControl).toEqual(delayed);
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+});

--- a/src/queries/name.ts
+++ b/src/queries/name.ts
@@ -1,0 +1,43 @@
+import { Control } from '@babylonjs/gui';
+import { BabylonContainer, findAllMatchingDescendants } from './utils';
+import { buildQueries } from '../query-helpers';
+
+const getMultipleError = (_c: BabylonContainer, name: string) =>
+    `Found multiple elements with the name: ${name}`;
+
+const getMissingError = (container: BabylonContainer, message: string) => {
+    return `Unable to find an element with the name: ${message}. Container: ${container}`;
+};
+
+/**
+ * Queries GUI controls by their Babylon `name`. Names are the Babylon-native
+ * equivalent of a test id: prefer the user-facing queries (ByText,
+ * ByPlaceholderText, ByDisplayValue) where possible and reach for ByName for
+ * icon buttons and other controls with no queryable text.
+ */
+const queryAllByName = (
+    container: BabylonContainer,
+    name: string
+): Control[] => {
+    return findAllMatchingDescendants(
+        container,
+        (control) => control.name === name
+    );
+};
+
+const {
+    queryBy: queryByName,
+    getAllBy: getAllByName,
+    getBy: getByName,
+    findAllBy: findAllByName,
+    findBy: findByName,
+} = buildQueries(queryAllByName, getMultipleError, getMissingError);
+
+export {
+    queryAllByName,
+    queryByName,
+    getAllByName,
+    getByName,
+    findAllByName,
+    findByName,
+};

--- a/src/realTimeWaits.ts
+++ b/src/realTimeWaits.ts
@@ -120,9 +120,17 @@ export const waitForRealTime = async <T>(
         // in-deadline pump is still honored.
         while (outcome === undefined) {
             if (!withinDeadline()) {
-                throw new Error(
-                    `Timed out in waitForRealTime: callback promise still pending after ${timeout}ms`
-                );
+                // Settlement is observed via microtask handlers, which may
+                // be queued but not yet run; drain once so a promise that
+                // settled just inside the deadline is not misreported as
+                // still pending.
+                await Promise.resolve();
+                if (outcome === undefined) {
+                    throw new Error(
+                        `Timed out in waitForRealTime: callback promise still pending after ${timeout}ms`
+                    );
+                }
+                break;
             }
             await pumpOnce(interval, wrapper);
         }

--- a/src/xrMocks.spec.ts
+++ b/src/xrMocks.spec.ts
@@ -1,0 +1,256 @@
+import {
+    AbstractMesh,
+    Engine,
+    IMotionControllerProfile,
+    MeshBuilder,
+    NullEngine,
+    Scene,
+    TransformNode,
+    Vector3,
+    WebXRFeatureName,
+    WebXRState,
+} from '@babylonjs/core';
+import {
+    buildMockControllersFromProfile,
+    createMockXRSession,
+    createMockXrController,
+    createMockXrControllerWithBindings,
+    createMockXrExperience,
+    createMockXrHand,
+    createMockXrInputSource,
+    setupBabylonExpect,
+} from './index';
+
+setupBabylonExpect();
+
+describe('createMockXrController', () => {
+    it('returns shared observables that reach component subscribers', () => {
+        const requested: string[] = [];
+        const { mockController, onButtonStateChangedObservable } =
+            createMockXrController((button) => requested.push(button));
+
+        const component = mockController.getComponent('xr-standard-trigger');
+        expect(requested).toEqual(['xr-standard-trigger']);
+
+        const listener = jest.fn();
+        component.onButtonStateChangedObservable.add(listener);
+        onButtonStateChangedObservable.notifyObservers({ pressed: true });
+
+        expect(listener).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('createMockXrControllerWithBindings', () => {
+    it('keeps a distinct observable pair per binding', () => {
+        const { mockController, componentObservableMap } =
+            createMockXrControllerWithBindings([
+                'xr-standard-trigger',
+                'xr-standard-thumbstick',
+            ]);
+
+        const trigger = jest.fn();
+        const thumbstick = jest.fn();
+        mockController
+            .getComponent('xr-standard-trigger')
+            .onButtonStateChangedObservable.add(trigger);
+        mockController
+            .getComponent('xr-standard-thumbstick')
+            .onButtonStateChangedObservable.add(thumbstick);
+
+        componentObservableMap[
+            'xr-standard-trigger'
+        ].onButtonStateChangedObservable.notifyObservers({ pressed: true });
+
+        expect(trigger).toHaveBeenCalledTimes(1);
+        expect(thumbstick).not.toHaveBeenCalled();
+    });
+});
+
+describe('createMockXrInputSource', () => {
+    it('defaults to a right-handed xr-standard source', () => {
+        const inputSource = createMockXrInputSource();
+
+        expect(inputSource.inputSource.handedness).toEqual('right');
+        expect(inputSource.inputSource.gamepad?.mapping).toEqual('xr-standard');
+        expect(inputSource.pointer.getChildMeshes()).toEqual([]);
+    });
+
+    it('honors the handedness option', () => {
+        const inputSource = createMockXrInputSource({ handedness: 'left' });
+        expect(inputSource.inputSource.handedness).toEqual('left');
+    });
+});
+
+describe('createMockXrExperience', () => {
+    it('exposes the hand tracking feature when enabled', () => {
+        const hand = createMockXrHand({});
+        const experience = createMockXrExperience({
+            handTrackingEnabled: true,
+            getHandByHandedness: () => hand,
+        });
+
+        const feature =
+            experience.baseExperience.featuresManager.getEnabledFeature(
+                WebXRFeatureName.HAND_TRACKING
+            );
+
+        expect(feature).toBeDefined();
+        expect(
+            (
+                feature as unknown as {
+                    getHandByHandedness: (h: string) => unknown;
+                }
+            ).getHandByHandedness('left')
+        ).toEqual(hand);
+    });
+
+    it('returns no feature when hand tracking is disabled', () => {
+        const experience = createMockXrExperience();
+
+        expect(
+            experience.baseExperience.featuresManager.getEnabledFeature(
+                WebXRFeatureName.HAND_TRACKING
+            )
+        ).toBeUndefined();
+        expect(experience.baseExperience.state).toEqual(WebXRState.IN_XR);
+    });
+});
+
+describe('createMockXrHand', () => {
+    let engine: Engine, scene: Scene;
+
+    beforeAll(() => {
+        engine = new NullEngine();
+    });
+
+    beforeEach(() => {
+        scene = new Scene(engine);
+    });
+
+    afterEach(() => {
+        scene.dispose();
+    });
+
+    afterAll(() => {
+        engine.dispose();
+    });
+
+    it('returns joint meshes by name', () => {
+        const tip = MeshBuilder.CreateBox('tip', { size: 0.01 }, scene);
+        const hand = createMockXrHand({ 'index-finger-tip': tip });
+
+        expect(hand.getJointMesh('index-finger-tip' as never)).toEqual(tip);
+        expect(
+            hand.getJointMesh('wrist' as never) as AbstractMesh | undefined
+        ).toBeUndefined();
+    });
+});
+
+describe('createMockXRSession', () => {
+    it('records listeners into the registry so tests can fire them', () => {
+        const registry: Record<string, () => void> = {};
+        const session = createMockXRSession(registry);
+
+        const onEnd = jest.fn();
+        session.addEventListener('end', onEnd);
+        expect(registry['end']).toBeDefined();
+
+        registry['end']();
+        expect(onEnd).toHaveBeenCalledTimes(1);
+
+        session.removeEventListener('end', onEnd);
+        expect(registry['end']).toBeUndefined();
+        expect(session.visibilityState).toEqual('visible');
+    });
+});
+
+describe('buildMockControllersFromProfile', () => {
+    let engine: Engine, scene: Scene;
+
+    beforeAll(() => {
+        engine = new NullEngine();
+    });
+
+    beforeEach(() => {
+        scene = new Scene(engine);
+    });
+
+    afterEach(() => {
+        scene.dispose();
+    });
+
+    afterAll(() => {
+        engine.dispose();
+    });
+
+    const profile = {
+        layouts: {
+            left: {
+                components: {
+                    'xr-standard-trigger': {
+                        visualResponses: {
+                            pressed: {
+                                valueNodeName: 'trigger_pressed_value',
+                                minNodeName: 'trigger_pressed_min',
+                                maxNodeName: 'trigger_pressed_max',
+                            },
+                        },
+                    },
+                    'xr-standard-thumbstick': {
+                        visualResponses: {
+                            yaxis: {
+                                valueNodeName: 'thumbstick_yaxis_value',
+                                minNodeName: 'thumbstick_yaxis_min',
+                                maxNodeName: 'thumbstick_yaxis_max',
+                            },
+                        },
+                    },
+                },
+            },
+            right: {
+                components: {
+                    'xr-standard-trigger': {
+                        visualResponses: {
+                            pressed: {
+                                valueNodeName: 'trigger_pressed_value',
+                                minNodeName: 'trigger_pressed_min',
+                                maxNodeName: 'trigger_pressed_max',
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    } as unknown as IMotionControllerProfile;
+
+    it('creates min/max/value nodes per visual response without GLB assets', () => {
+        const { left, right } = buildMockControllersFromProfile(profile, scene);
+
+        expect(left.name).toEqual('left-controller-mock');
+        expect(right.name).toEqual('right-controller-mock');
+
+        const names = (left as unknown as TransformNode)
+            .getChildren()
+            .map((node) => node.name);
+        expect(names).toEqual(
+            expect.arrayContaining([
+                'trigger_pressed_min',
+                'trigger_pressed_max',
+                'trigger_pressed_value',
+                'thumbstick_yaxis_min',
+                'thumbstick_yaxis_max',
+                'thumbstick_yaxis_value',
+            ])
+        );
+    });
+
+    it('keeps thumbstick y-axis min == max so mid-step lerps are assertable', () => {
+        buildMockControllersFromProfile(profile, scene);
+
+        const min = scene.getTransformNodeByName('thumbstick_yaxis_min');
+        const max = scene.getTransformNodeByName('thumbstick_yaxis_max');
+
+        expect(min?.position).toEqualVector3(new Vector3(0, 0.02, 0));
+        expect(max?.position).toEqualVector3(new Vector3(0, 0.02, 0));
+    });
+});

--- a/src/xrMocks.ts
+++ b/src/xrMocks.ts
@@ -1,0 +1,281 @@
+import {
+    AbstractMesh,
+    IMotionControllerProfile,
+    IWebXRFeature,
+    Observable,
+    Quaternion,
+    Scene,
+    TransformNode,
+    WebXRAbstractMotionController,
+    WebXRDefaultExperience,
+    WebXRFeatureName,
+    WebXRHand,
+    WebXRHandTracking,
+    WebXRInputSource,
+    WebXRState,
+} from '@babylonjs/core';
+
+/**
+ * Headless mocks for Babylon's WebXR surface, for testing hand- and
+ * controller-driven UI (hand menus, controller menus, near interaction)
+ * without a device, a session, or GLB controller assets. The observables are
+ * real Babylon Observables — tests drive them with notifyObservers.
+ */
+
+export interface MockXrController {
+    onButtonStateChangedObservable: Observable<unknown>;
+    onAxisValueChangedObservable: Observable<unknown>;
+    mockController: WebXRAbstractMotionController;
+}
+
+/**
+ * A motion controller whose every component shares one pair of button/axis
+ * observables — notify them to simulate input on whatever component the code
+ * under test requested. `onGetComponent` observes which components are
+ * looked up.
+ */
+export function createMockXrController(
+    onGetComponent?: (button: string) => void
+): MockXrController {
+    const onButtonStateChangedObservable = new Observable<unknown>();
+    const onAxisValueChangedObservable = new Observable<unknown>();
+    const onModelLoadedObservable = new Observable<unknown>();
+
+    const mockController = {
+        getComponent: (button: string) => {
+            onGetComponent?.(button);
+            return {
+                onAxisValueChangedObservable,
+                onButtonStateChangedObservable,
+            };
+        },
+        handedness: 'right',
+        onModelLoadedObservable,
+    } as unknown as WebXRAbstractMotionController;
+
+    return {
+        onButtonStateChangedObservable,
+        onAxisValueChangedObservable,
+        mockController,
+    };
+}
+
+export interface MockXrComponentObservables {
+    onButtonStateChangedObservable: Observable<unknown>;
+    onAxisValueChangedObservable: Observable<unknown>;
+}
+
+/**
+ * A motion controller with a distinct observable pair per named component
+ * binding, for tests that need to tell thumbstick input from button input.
+ */
+export function createMockXrControllerWithBindings(bindings: string[]) {
+    const componentObservableMap: Record<string, MockXrComponentObservables> =
+        Object.fromEntries(
+            bindings.map((button) => {
+                const onButtonStateChangedObservable =
+                    new Observable<unknown>();
+                const onAxisValueChangedObservable = new Observable<unknown>();
+                return [
+                    button,
+                    {
+                        onButtonStateChangedObservable,
+                        onAxisValueChangedObservable,
+                    },
+                ];
+            })
+        );
+
+    const mockController = {
+        getComponent: (button: string) => {
+            return componentObservableMap[button];
+        },
+        handedness: 'right',
+        onModelLoadedObservable: new Observable<unknown>(),
+    } as unknown as WebXRAbstractMotionController;
+
+    return { mockController, componentObservableMap };
+}
+
+export interface MockXrInputSourceOptions {
+    /** Invoked when the first observer of onMotionControllerInitObservable is added. */
+    onMotionControllerInit?: () => void;
+    /** Invoked when the first observer of onMeshLoadedObservable is added. */
+    onMeshLoaded?: () => void;
+    handedness?: XRHandedness;
+}
+
+/**
+ * An XR input source with an 'xr-standard' gamepad mapping and a stub
+ * pointer mesh — enough for controller-discovery and menu-placement logic.
+ */
+export function createMockXrInputSource(
+    options: MockXrInputSourceOptions = {}
+): WebXRInputSource {
+    const {
+        onMotionControllerInit,
+        onMeshLoaded,
+        handedness = 'right',
+    } = options;
+
+    return {
+        onMotionControllerInitObservable: new Observable(
+            onMotionControllerInit
+        ),
+        onMeshLoadedObservable: new Observable(onMeshLoaded),
+        inputSource: {
+            handedness,
+            gamepad: {
+                mapping: 'xr-standard',
+            },
+            profiles: ['pico-4'],
+        },
+        pointer: {
+            getChildMeshes: () => [],
+            setEnabled: () => null,
+        } as unknown as AbstractMesh,
+    } as WebXRInputSource;
+}
+
+export interface MockXrExperienceOptions {
+    /** Invoked when the first observer of input.onControllerAddedObservable is added. */
+    onControllerAdded?: () => void;
+    /** When true, getEnabledFeature(HAND_TRACKING) returns a mock hand-tracking feature. */
+    handTrackingEnabled?: boolean;
+    state?: WebXRState;
+    getHandByControllerId?: (id: string) => WebXRHand;
+    getHandByHandedness?: (handedness: XRHandedness) => WebXRHand;
+}
+
+/**
+ * A WebXRDefaultExperience covering the observable surface hand/controller
+ * menu code touches: controller added, state changes, session init, and the
+ * hand-tracking feature lookup.
+ */
+export function createMockXrExperience(
+    options: MockXrExperienceOptions = {}
+): WebXRDefaultExperience {
+    const {
+        onControllerAdded,
+        handTrackingEnabled = false,
+        state = WebXRState.IN_XR,
+        getHandByControllerId = () => null as unknown as WebXRHand,
+        getHandByHandedness = () => null as unknown as WebXRHand,
+    } = options;
+
+    return {
+        input: {
+            onControllerAddedObservable: new Observable(onControllerAdded),
+        },
+        baseExperience: {
+            featuresManager: {
+                getEnabledFeature: (value: string) => {
+                    if (
+                        handTrackingEnabled &&
+                        value === WebXRFeatureName.HAND_TRACKING
+                    ) {
+                        return {
+                            onHandAddedObservable: new Observable<WebXRHand>(),
+                            onHandRemovedObservable:
+                                new Observable<WebXRHand>(),
+                            isCompatible: () => true,
+                            getHandByControllerId: getHandByControllerId,
+                            getHandByHandedness: getHandByHandedness,
+                            attach: () => true,
+                            detach: () => true,
+                            dispose: () => null,
+                        } as unknown as WebXRHandTracking;
+                    }
+                    return undefined as unknown as IWebXRFeature;
+                },
+            },
+            onStateChangedObservable: new Observable(),
+            sessionManager: {
+                onXRSessionInit: new Observable(),
+            },
+            state,
+        },
+    } as WebXRDefaultExperience;
+}
+
+/**
+ * A WebXRHand whose joint meshes are supplied by name (e.g.
+ * 'index-finger-tip'); getJointMesh returns the matching mesh so tests can
+ * read or animate a joint's world transform.
+ */
+export function createMockXrHand(
+    jointMeshes: Record<string, AbstractMesh>
+): WebXRHand {
+    return {
+        getJointMesh: (jointName: string) => jointMeshes[jointName],
+        handMesh: null,
+    } as unknown as WebXRHand;
+}
+
+/**
+ * An XRSession that records event listeners into the given registry so tests
+ * can invoke them (e.g. registry['end']()) to simulate session events.
+ */
+export function createMockXRSession(
+    registry: Record<string, () => void>
+): XRSession {
+    return {
+        addEventListener: (name: string, callback: () => void) => {
+            registry[name] = callback;
+        },
+        removeEventListener: (name: string) => {
+            delete registry[name];
+        },
+        visibilityState: 'visible',
+    } as unknown as XRSession;
+}
+
+/**
+ * Builds minimal controller node hierarchies from a WebXR motion controller
+ * profile: the pressed min/max/value nodes for each visual response, so
+ * button/thumbstick animation code runs without loading GLB assets.
+ * Thumbstick Y-axis responses keep min == max so a mid-step lerp reaches an
+ * assertable position.
+ */
+export function buildMockControllersFromProfile(
+    profile: IMotionControllerProfile,
+    scene: Scene
+): Record<string, AbstractMesh> {
+    const make = (handedness: 'left' | 'right') => {
+        // A TransformNode root so instantiateHierarchy clones a hierarchy.
+        const root = new TransformNode(`${handedness}-controller-mock`, scene);
+        const comps = Object.values(profile.layouts[handedness].components);
+        for (const comp of comps) {
+            const vr = comp.visualResponses as Record<
+                string,
+                {
+                    valueNodeName: string;
+                    minNodeName: string;
+                    maxNodeName: string;
+                }
+            >;
+            for (const key in vr) {
+                const { valueNodeName, minNodeName, maxNodeName } = vr[key];
+                const mk = (name: string): TransformNode => {
+                    const tn = new TransformNode(name, scene);
+                    tn.rotationQuaternion = Quaternion.Identity();
+                    tn.parent = root;
+                    return tn;
+                };
+                const min = mk(minNodeName);
+                const max = mk(maxNodeName);
+                const value = mk(valueNodeName);
+                if (valueNodeName.includes('thumbstick_yaxis')) {
+                    min.position.set(0, 0.02, 0);
+                    max.position.set(0, 0.02, 0);
+                } else {
+                    min.position.set(0, 0, 0);
+                    max.position.set(0.01, 0.01, 0);
+                }
+                value.position.set(0, 0, 0);
+            }
+        }
+        return root as unknown as AbstractMesh;
+    };
+    return { left: make('left'), right: make('right') };
+}


### PR DESCRIPTION
Consolidated follow-up to #33 — everything ships together as the single **3.1.0** release (the pre-Tier-1 3.1.0 tag/GitHub release never reached npm and has been deleted; it will be recreated at this PR's merged head). Pure Babylon throughout — no new dependencies, no React anywhere in the tree.

## New API

**Queries** — `*ByName` (GUI controls by Babylon `name`, the engine-native test-id analog) and `*ByMeshName` (3D meshes; `findBy*` waits in real elapsed time, fake-timer safe). Full query/get/find × single/all variants.

**Mesh pointer simulation** — `getPickInfo` / `fireMeshPointer` / `clickMesh` / `hoverMesh` / `pickThinInstance`: real ray picks that render and recompute the target inside every retry, notify `scene.onPointerObservable` exactly as Babylon's input layer would, honor `isPickable`/`isEnabled`/`isVisible` by default (Babylon silently skips those checks when any predicate is supplied — without this, tests happily click disabled buttons), and support `pointerType` tagging.

**Finger-poke stack (near interaction)** — `probePoke` (oriented-frame fingertip geometry, thinnest axis = press axis, allocation-free), `stepPoke` + `createPokeMemory` + `DEFAULT_POKE_THRESHOLDS` (hover/press/release state machine with hysteresis + per-press debounce, hardware-tuned thresholds), `pokeFrame`/`pokeRelease` (inject `xr-near`-tagged `PointerInfo`s so mesh-button pipelines react as with a controller pointer; disabled hitboxes are skipped — ancestor-folded `isEnabled`, the on-device palm-gate lesson). Specs are fully self-contained: event-sequence contracts, click-consumer integration, lateral miss, debounce, nearest-hitbox selection, tracking-loss release without stale re-fires.

**WebXR mocks** — `createMockXrExperience` / `createMockXrInputSource` / `createMockXrController(WithBindings)` / `createMockXrHand` / `createMockXRSession` / `buildMockControllersFromProfile`. Headless hand/controller-menu testing with real Babylon `Observable`s; options-object signatures.

**Matchers** — `setupBabylonExpect()` / `babylonMatchers`: `toEqualVector3/Quaternion/Matrix/Color3/Color4` with optional epsilon; signatures carry no jest type dependency; the `jest.Matchers` augmentation merges with @types/jest when present.

## Fixes
- **`fireEvent.pointerMove` fired `onPointerUpObservable`** (event-map copy-paste); now `onPointerMoveObservable` with the correct `Vector2` payload. Behavior fix.
- **`waitForRealTime`** drains a microtask before declaring a callback promise pending at the deadline (a settled-but-unobserved rejection could be misreported as the pending-timeout error — found by an 8× flake hunt, 3/6 repro before, 0/8 after).

## Notes
- Thin-instance spec uses `thinInstanceSetBuffer` (`thinInstanceAdd` is gated on `caps.instancedArrays`, absent under NullEngine).
- 399 tests / 16 suites; build, lint, format:check green.
- Verified end-to-end in webapp (rebeckerspecialties/webapp#1258) against the packed artifact: test-utils, renderer, and the full visualization suite green with these modules substituted for the local test-utils copies.
- **Release runbook once npm auth is fixed (#34):** merge this PR → create GitHub release tagged `3.1.0` → workflow publishes. One release, everything included.

**Addendum:** `src/examples/handMenu.spec.ts` — a runnable, headless WebXR hand-menu example composed entirely from public API (mock tracked hand → per-frame `pokeFrame` wiring → OrnamentButton-style poke buttons), covering click targeting, hover raise, the xr-near squeeze skip, palm-down gating, double-tap debounce, and tracking-loss release. README gains a walkthrough section with the on-device HandConstraintBehavior PALM_UP note. 406 tests / 17 suites.